### PR TITLE
Add link export endpoint and UI

### DIFF
--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -7,7 +7,8 @@ import {
 } from '@girder/components/src';
 import { itemsPerPageOptions } from 'dive-common/constants';
 import { clientSettings } from 'dive-common/store/settings';
-import { useStore, LocationType } from '../store/types';
+import { getUri } from 'platform/web-girder/api';
+import { useStore, LocationType, RootlessLocationType } from '../store/types';
 import Upload from './Upload.vue';
 import eventBus from '../eventBus';
 
@@ -62,6 +63,13 @@ export default defineComponent({
       navigator.clipboard.writeText(text);
     };
 
+    const exportLinks = () => {
+      const id = locationStore.location && (locationStore.location as RootlessLocationType)._id;
+      const url = `UMD_dataset/links/${id}`;
+      const link = getUri({ url });
+      window.location.assign(link);
+    };
+
     return {
       fileManager,
       locationStore,
@@ -77,6 +85,7 @@ export default defineComponent({
       setLocation,
       updateUploading,
       copyLink,
+      exportLinks,
     };
   },
 });
@@ -125,6 +134,20 @@ export default defineComponent({
           @close="uploaderDialog = false"
         />
       </v-dialog>
+      <v-btn
+        class="ma-0"
+        text
+        small
+        @click="exportLinks()"
+      >
+        <v-icon
+          left
+          color="accent"
+        >
+          mdi-file-delimited
+        </v-icon>
+        Export Links
+      </v-btn>
     </template>
     <template #row="{item}">
       <span>{{ item.name }}</span>

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -327,3 +327,36 @@ def convert_to_zips(folders, userMap, user):
         yield z.footer()
 
     return stream
+
+def generate_links_tab(url, folders):
+    def downloadGenerator():
+        for data in export_links_tab(url, folders):
+            yield data
+
+    return downloadGenerator
+
+def export_links_tab(url, folders):
+    csvFile = io.StringIO()
+    writer = csv.writer(csvFile, delimiter='\t')
+    writer.writerow(
+        [
+            "Name",
+            "V/A/E",
+            "Norms",
+            "Changepoint",
+            "Remediation",
+        ]
+    )
+    for folder in folders:
+        name = folder['name']
+        root = f'{url}/viewer/{folder["_id"]}?mode='
+        vae = f'{root}VAE'
+        norms = f'{root}norms'
+        changepoint = f'{root}changepoint'
+        remediation = f'{root}remediation'
+        columns = [ name, vae, norms, changepoint, remediation]
+        writer.writerow(columns)
+        yield csvFile.getvalue()
+        csvFile.seek(0)
+        csvFile.truncate(0)
+    yield csvFile.getvalue()


### PR DESCRIPTION
Adds a simple 'Export Links' button to a root folder filled with videos.  This creates a CSV file that has the name of the video file and direct links to the different modes.