### PR TITLE
add watchtower to update Saturdays at 2:00 AM

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,24 +51,10 @@ services:
     restart: always
     command: >
       --rolling-restart
-      --schedule "0 0 2 * * 4"
+      --schedule "0 0 2 ? * SAT"
       --label-enable
     environment:
       - "TZ=${TIMEZONE:-America/New_York}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
-  duplicati:
-    image: linuxserver/duplicati:latest
-    container_name: duplicati
-    restart: always
-    ports:
-      - "8200:8200" # Port is not exposed outside vpn
-    environment:
-      - "TZ=${TIMEZONE:-America/New_York}"
-      - "PUID=0" # Requires root to access docker volumes directory
-      - "PGID=0"
-    volumes:
-      - /var/lib/docker/volumes:/source_volumes:ro # backup source
-      - /var/local/backups:/destination_backups:rw # backup dest
-      - /var/local/backups/duplicati/config:/config:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,7 @@ services:
       - "RABBITMQ_MANAGEMENT_URL=${RABBITMQ_MANAGEMENT_URL:-http://rabbit:15672/}"
       - "RABBITMQ_MANAGEMENT_BROKER_URL_TEMPLATE=${RABBITMQ_MANAGEMENT_BROKER_URL_TEMPLATE}"
     labels:
-      # REMOVING WEEKLY UPDATE
-      # - "com.centurylinklabs.watchtower.enable=true"
+      - "com.centurylinklabs.watchtower.enable=true"
       - "traefik.enable=true"
       - "traefik.http.services.girder-svc.loadbalancer.server.port=8080"
       - "traefik.http.routers.girder-rtr.entrypoints=web"


### PR DESCRIPTION
resolves #34 

https://containrrr.dev/watchtower/lifecycle-hooks/
To do manual updates I think I would need to use watchtower lifecycle hooks which would run a script within the container and determine if the container should be updated.  This would be a shell script which would check for the existence of a file on the OS or some flag that is set and return the proper exit code to enable the update.  If the file/flag doesn't exist it returns an exit code of 75 to prevent updating.
This would require that we have the update frequency a bit higher like once every hour, but would require an admin action on the server to indicate that it should update.