### PR TITLE
sort folder links

### DIFF
--- a/server/UMD_server/UMD_dataset/views.py
+++ b/server/UMD_server/UMD_dataset/views.py
@@ -38,6 +38,7 @@ class UMD_Dataset(Resource):
         folder,
     ):
         subFolders = Folder().childFolders(folder, 'folder')
+        subFolders = sorted(subFolders, key=lambda d: d['created'])
         replacedHostname = getApiUrl().replace('/girder/api/v1', '/#')
         gen = UMD_export.generate_links_tab(replacedHostname, subFolders)
         setContentDisposition('FolderLinks.csv', mime='text/csv')


### PR DESCRIPTION
resolves #33 

Simple change to sort the subfolders by 'created'.
Checked the created dates with my sample local install and it was proper sorting with the newest ones at the bottom.