### PR TITLE
Set timeline height when mode is active

### DIFF
--- a/client/dive-common/components/ControlsContainer.vue
+++ b/client/dive-common/components/ControlsContainer.vue
@@ -311,6 +311,7 @@ export default defineComponent({
       :frame-rate="displayFrameRate"
       :display="!collapsed"
       :max-segment="maxSegment"
+      :mode="mode"
       @seek="seek"
     >
       <template

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -345,7 +345,7 @@ export default {
       position: absolute;
       top: 0;
       width: 100%;
-      height: 100%;
+      height: calc(100% - 13px);
       background-color: rgba($color: #c9c9c9, $alpha: 0.75);
       z-index:1;
     }

--- a/client/src/components/controls/Timeline.vue
+++ b/client/src/components/controls/Timeline.vue
@@ -267,6 +267,7 @@ export default {
 <template>
   <div
     class="timeline"
+    :class="{mode: mode !== undefined}"
     @wheel="onwheel"
     @mouseup="containerMouseup"
     @mousemove="containerMousemove"
@@ -368,6 +369,11 @@ export default {
     }
   }
 }
+.mode {
+  min-height: 75px !important;
+  max-height: 75px !important;
+}
+
 </style>
 
 <style lang="scss">


### PR DESCRIPTION
resolves #39 

Sets timeline height to 75px when the mode is set for annotators.

![image](https://user-images.githubusercontent.com/61746913/213251526-daeb5f06-e171-4350-9941-a2307936e977.png)
