### PR TITLE
add admin button to pull docker images

### DIFF
--- a/client/platform/web-girder/api/UMD.service.ts
+++ b/client/platform/web-girder/api/UMD.service.ts
@@ -5,7 +5,12 @@ function ingestVideo(folderId: string) {
   return girderRest.post(`${rootAPI}/ingest_video/${folderId}`);
 }
 
+function updateContainers() {
+  return girderRest.post(`${rootAPI}/update_containers`);
+}
+
+
 export {
-  // eslint-disable-next-line import/prefer-default-export
   ingestVideo,
+  updateContainers,
 };

--- a/client/platform/web-girder/views/Admin/AdminUpdate.vue
+++ b/client/platform/web-girder/views/Admin/AdminUpdate.vue
@@ -1,0 +1,79 @@
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api';
+import { updateContainers } from 'platform/web-girder/api/UMD.service';
+
+export default defineComponent({
+  name: 'AdminUpdate',
+  setup() {
+    const loading = ref(false);
+    const complete = ref('');
+    const reloadTime = ref(0);
+
+    const update = async () => {
+      loading.value = true;
+      try {
+        const result = await updateContainers();
+        loading.value = false;
+        complete.value = 'Already Updated';
+      } catch (error) {
+        console.log(error);
+        // When it is good the container restarts resulting a badgateway 502 error
+        // We should wait like 20 seconds after the error and reload the page to show the update
+        if (error.response && error.response.status === 502) {
+          complete.value = 'Reload';
+          reloadTime.value = 20;
+          setInterval(() => {
+            reloadTime.value -= 1;
+            if (reloadTime.value === 0) {
+              // eslint-disable-next-line no-restricted-globals
+              location.reload();
+            }
+          }, 1000);
+        }
+      }
+    };
+    return {
+      update,
+      loading,
+      complete,
+      reloadTime,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-container>
+    <v-card>
+      <v-card-title> Update </v-card-title>
+      <v-card-text>
+        <p style="font-size:1.5em">
+          Below is a button that will pull the latest images from the Docker
+          repository and redeploy the server. The server will temporarily stop
+          for a few seconds while it relaunches. Please ensure that no jobs are
+          running when you press this button.
+        </p>
+        <v-alert type="warning" v-if="complete == 'Reload'">
+          <h2>
+            Update is complete: Reloading the page in {{ reloadTime }} seconds
+          </h2>
+        </v-alert>
+        <v-alert type="info" v-if="complete == 'Already Updated'">
+          <h2>
+            The system is already up to date and doesn't need to pull the latest containers.
+          </h2>
+        </v-alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" class="ml-2" :disable="complete" @click="update">
+          <v-icon>
+            {{ loading ? "mdi-spin mdi-sync" : "" }}
+          </v-icon>
+
+          Update
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-container>
+</template>

--- a/client/platform/web-girder/views/AdminPage.vue
+++ b/client/platform/web-girder/views/AdminPage.vue
@@ -5,6 +5,7 @@ import AdminRecents from './Admin/AdminRecents.vue';
 import UserRecents from './Admin/UserRecents.vue';
 import AdminJobs from './Admin/AdminJobs.vue';
 import AdminBranding from './Admin/AdminBranding.vue';
+import AdminUpdate from './Admin/AdminUpdate.vue';
 
 export default {
   name: 'AdminPage',
@@ -14,6 +15,7 @@ export default {
     UserRecents,
     AdminJobs,
     AdminBranding,
+    AdminUpdate,
   },
   props: {
   },
@@ -36,6 +38,7 @@ export default {
           <v-tab> Jobs </v-tab>
           <v-tab> Addons </v-tab>
           <v-tab> Branding </v-tab>
+          <v-tab> Update </v-tab>
         </v-tabs>
       </v-card-title>
       <v-tabs-items v-model="currentTab">
@@ -53,6 +56,9 @@ export default {
         </v-tab-item>
         <v-tab-item>
           <AdminBranding />
+        </v-tab-item>
+        <v-tab-item>
+          <AdminUpdate />
         </v-tab-item>
       </v-tabs-items>
 


### PR DESCRIPTION
resolves #46 

Adds a UI to pull new containers from the registry.  The watchtower endpoint when it succeeds will restart girder which will leave the user with a 502 badgateway.  I catch this error and notify the user that I will be reloading the page in 20 seconds (to give enough time for the containers to start back up).  If the user already has the latest containers it will notify them that the latest containers exist.

https://user-images.githubusercontent.com/61746913/214669121-365aeb4f-da62-4c6e-8910-9957fa15c422.mp4


