### PR TITLE
add simple storage method

### DIFF
--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -72,6 +72,14 @@ export default defineComponent({
     const normsObject: Ref<Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>> = ref({});
     const userLogin = ref('');
     const loadedAttributes = ref(false);
+    let dataStore: {
+      arousal?: number;
+      valence?: number;
+      emotionsList?: string[];
+      multiSpeaker?: 'FALSE' | 'TRUE' | 'noann';
+      normsSelected?: string[];
+      normsObject?: Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>;
+    } = {};
 
     const checkAttributes = (trackNum: number | null, loadValues = false) => {
       // load existing attributes
@@ -134,6 +142,32 @@ export default defineComponent({
     loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
     watch(selectedTrackIdRef, () => {
       loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
+      if (selectedTrackIdRef.value === maxSegment.value && !loadedAttributes.value) {
+        // Load stored values
+        if (props.mode === 'VAE') {
+          if (dataStore.arousal) {
+            arousal.value = dataStore.arousal;
+          }
+          if (dataStore.valence) {
+            valence.value = dataStore.valence;
+          }
+          if (dataStore.multiSpeaker) {
+            multiSpeaker.value = dataStore.multiSpeaker;
+          }
+          if (dataStore.emotionsList) {
+            emotionsList.value = dataStore.emotionsList;
+          }
+        }
+        if (props.mode === 'norms') {
+          if (dataStore.normsSelected) {
+            normsSelected.value = dataStore.normsSelected;
+          }
+          if (dataStore.normsObject) {
+            normsObject.value = dataStore.normsObject;
+          }
+        }
+        dataStore = {};
+      }
       if (selectedTrackIdRef.value !== null) {
         handler.setMaxSegment(selectedTrackIdRef.value);
       }
@@ -184,6 +218,18 @@ export default defineComponent({
       }
     };
     const changeTrack = (direction: -1 | 1) => {
+      if (selectedTrackIdRef.value === maxSegment.value) {
+        if (props.mode === 'VAE') {
+          dataStore.arousal = arousal.value;
+          dataStore.valence = valence.value;
+          dataStore.multiSpeaker = multiSpeaker.value;
+          dataStore.emotionsList = emotionsList.value;
+        }
+        if (props.mode === 'norms') {
+          dataStore.normsSelected = normsSelected.value;
+          dataStore.normsObject = normsObject.value;
+        }
+      }
       arousal.value = 1;
       valence.value = 1;
       emotionsList.value = [];


### PR DESCRIPTION
resolve #57 

Right now it's using simple in-memory storage of the furthest resubmitted segment values.  So you can go back and forth through the other options and checking them out.  I didn't do anything more complicated (not too bad) like storing the data in local storage.  This solves the problem of checking your previous values without losing your current value.

This won't hold onto previous values that you change in earlier segments.  Like if your resubmitted segment is segment 5 and you go back and change segment's 3 valence value and don't click update.  If you don't click update it won't hold onto the value of that segment but it will hold onto the segment's 5 values that were set before hitting the previous button.