### PR TITLE
Improve norm variant ordering

### DIFF
--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -70,12 +70,13 @@ export default defineComponent({
         'Finalizing Negotiating/Deal',
         'Refusing a Request',
       ];
-      const rootAhered = root.map((item) => `${item} adhered`);
-      const rootViolate = root.map((item) => `${item} violate`);
+      const normVariants = root
+        .map((item) => [`${item} (adhered)`, `${item} (violated)`])
+        .reduce((acc, x) => acc.concat(x));
+
       return [
         'None',
-        ...rootAhered,
-        ...rootViolate,
+        ...normVariants,
       ];
     });
     const normsObject: Ref<Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>> = ref({});


### PR DESCRIPTION
This orders the norm variants by norm--that is, it goes:
- Apology (adhered)
- Apology (violated)
- Criticism (adhered)
- Criticism (violated)
- ...

instead of:
- Apology (adhered)
- Criticism (adhered)
- ...
- Apology (violated)
- Criticism (violated)

which enables the annotator to process a single norm in both its adhered and violated states before moving onto the next norm.

It also puts the state value in parentheses instead of simply appending it to the name of the norm. And finally, this changes the words used to `adhered` and `violated` (the latter was `violate` before).

I am not sure how we extract the adhered/violated state from the item in this list, but if it's done by parsing the value that logic will likely need to change. (If you point me to that area of the code, I can go ahead and push a commit to this branch to fix it up.)