### PR TITLE
Allow duplicate Norms

### DIFF
--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -46,7 +46,10 @@ export default defineComponent({
       if (emotionsList.value.includes('No emotions')) {
         return ['No emotions'];
       }
-      return ['No emotions', 'Anger', 'Anticipation', 'Joy', 'Trust', 'Fear', 'Surprise', 'Sadness', 'Disgust'];
+      const root = ['Anger', 'Anticipation', 'Joy', 'Trust', 'Fear', 'Surprise', 'Sadness', 'Disgust'];
+      const rootAhered = root.map((item) => `${item} adhered`);
+      const rootViolate = root.map((item) => `${item} violate`);
+      return ['No emotions', ...rootAhered, ...rootViolate];
     });
     const multiSpeakerOptions = ref(['FALSE', 'TRUE', 'noann']);
     const multiSpeaker: Ref<'FALSE' | 'TRUE' | 'noann'> = ref('FALSE');
@@ -55,8 +58,7 @@ export default defineComponent({
       if (normsSelected.value.includes('None')) {
         return ['None'];
       }
-      return [
-        'None',
+      const root = [
         'Apology',
         'Criticism',
         'Greeting',
@@ -68,10 +70,24 @@ export default defineComponent({
         'Finalizing Negotiating/Deal',
         'Refusing a Request',
       ];
+      const rootAhered = root.map((item) => `${item} adhered`);
+      const rootViolate = root.map((item) => `${item} violate`);
+      return [
+        'None',
+        ...root,
+      ];
     });
     const normsObject: Ref<Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>> = ref({});
     const userLogin = ref('');
     const loadedAttributes = ref(false);
+    let dataStore: {
+      arousal?: number;
+      valence?: number;
+      emotionsList?: string[];
+      multiSpeaker?: 'FALSE' | 'TRUE' | 'noann';
+      normsSelected?: string[];
+      normsObject?: Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>;
+    } = {};
 
     const checkAttributes = (trackNum: number | null, loadValues = false) => {
       // load existing attributes
@@ -134,6 +150,32 @@ export default defineComponent({
     loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
     watch(selectedTrackIdRef, () => {
       loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
+      if (selectedTrackIdRef.value === maxSegment.value && !loadedAttributes.value) {
+        // Load stored values
+        if (props.mode === 'VAE') {
+          if (dataStore.arousal) {
+            arousal.value = dataStore.arousal;
+          }
+          if (dataStore.valence) {
+            valence.value = dataStore.valence;
+          }
+          if (dataStore.multiSpeaker) {
+            multiSpeaker.value = dataStore.multiSpeaker;
+          }
+          if (dataStore.emotionsList) {
+            emotionsList.value = dataStore.emotionsList;
+          }
+        }
+        if (props.mode === 'norms') {
+          if (dataStore.normsSelected) {
+            normsSelected.value = dataStore.normsSelected;
+          }
+          if (dataStore.normsObject) {
+            normsObject.value = dataStore.normsObject;
+          }
+        }
+        dataStore = {};
+      }
       if (selectedTrackIdRef.value !== null) {
         handler.setMaxSegment(selectedTrackIdRef.value);
       }
@@ -184,6 +226,18 @@ export default defineComponent({
       }
     };
     const changeTrack = (direction: -1 | 1) => {
+      if (selectedTrackIdRef.value === maxSegment.value) {
+        if (props.mode === 'VAE') {
+          dataStore.arousal = arousal.value;
+          dataStore.valence = valence.value;
+          dataStore.multiSpeaker = multiSpeaker.value;
+          dataStore.emotionsList = emotionsList.value;
+        }
+        if (props.mode === 'norms') {
+          dataStore.normsSelected = normsSelected.value;
+          dataStore.normsObject = normsObject.value;
+        }
+      }
       arousal.value = 1;
       valence.value = 1;
       emotionsList.value = [];

--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -13,6 +13,9 @@ import {
   useTime,
 } from 'vue-media-annotator/provides';
 
+
+type NormsObjectValues = Record<string, 'adhered' |'violated' | 'EMPTY_NA' | 'adhered_violated'>;
+
 export default defineComponent({
   name: 'UMDAnnotation',
 
@@ -97,7 +100,7 @@ export default defineComponent({
         ...normVariants,
       ];
     });
-    const normsObject: Ref<Record<string, 'adhered' |'violated' | 'noann' | 'adhered_violated'>> = ref({});
+    const normsObject: Ref<NormsObjectValues> = ref({});
     const userLogin = ref('');
     const loadedAttributes = ref(false);
     let dataStore: {
@@ -106,7 +109,7 @@ export default defineComponent({
       emotionsList?: string[];
       multiSpeaker?: 'FALSE' | 'TRUE' | 'noann';
       normsSelected?: string[];
-      normsObject?: Record<string, 'adhered' |'violated' | 'noann' | 'adhered_violated'>;
+      normsObject?: NormsObjectValues;
     } = {};
 
     let framePlaying = -1;
@@ -166,7 +169,7 @@ export default defineComponent({
             }
             if (replaced === 'Norms' && props.mode === 'norms') {
               if (loadValues) {
-                normsObject.value = (track.attributes[key] as Record<string, 'adhered' |'violated' | 'noann' | 'adhered_violated'>);
+                normsObject.value = (track.attributes[key] as NormsObjectValues);
                 normsSelected.value = [];
                 Object.entries(normsObject.value).forEach(([normKey, val]) => {
                   const adhered = `${normKey} (adhered)`;
@@ -177,7 +180,7 @@ export default defineComponent({
                   if (val.includes('violated')) {
                     normsSelected.value.push(violated);
                   }
-                  if (val.includes('noann')) {
+                  if (val.includes('noann') || val.includes('EMPTY_NA')) {
                     normsSelected.value.push('None');
                   }
                 });
@@ -332,7 +335,7 @@ export default defineComponent({
         }
       }
       if (data.includes('None')) {
-        normsObject.value.None = 'noann';
+        normsObject.value.None = 'EMPTY_NA';
       } else {
         for (let i = 0; i < data.length; i += 1) {
           let adhered = data[i].includes('(adhered)');

--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -47,9 +47,7 @@ export default defineComponent({
         return ['No emotions'];
       }
       const root = ['Anger', 'Anticipation', 'Joy', 'Trust', 'Fear', 'Surprise', 'Sadness', 'Disgust'];
-      const rootAhered = root.map((item) => `${item} adhered`);
-      const rootViolate = root.map((item) => `${item} violate`);
-      return ['No emotions', ...rootAhered, ...rootViolate];
+      return ['No emotions', ...root];
     });
     const multiSpeakerOptions = ref(['FALSE', 'TRUE', 'noann']);
     const multiSpeaker: Ref<'FALSE' | 'TRUE' | 'noann'> = ref('FALSE');

--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -74,7 +74,8 @@ export default defineComponent({
       const rootViolate = root.map((item) => `${item} violate`);
       return [
         'None',
-        ...root,
+        ...rootAhered,
+        ...rootViolate,
       ];
     });
     const normsObject: Ref<Record<string, 'adhered' |'violate' | 'noann' | 'EMPTY_NA'>> = ref({});

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -21,7 +21,17 @@ normMap = {
     "Admiration": 108,
     "Finalizing Negotiation/Deal": 109,
     "Refusing a Request": 110,
+    "None": 'none',
 }
+
+normValuesViolate = ['violate', 'violated']
+normValuesAdhere = ['adhere', 'adhered']
+normValuesAdhereViolate = ['adhere_violate', 'adhered_violated']
+normValuesNone = ['noann', 'EMPTY_NA']
+normViolate = 'violate'
+normAdhere = 'adhere'
+NormAdhereViolate = 'adhere_violate'
+normNone = 'EMPTY_NA'
 
 
 def bin_value(value):
@@ -152,17 +162,17 @@ def export_norms_tab(folders, userMap, user):
                 for key in userDataFound.keys():
                     for normKey in userDataFound[key].keys():
                         value = userDataFound[key][normKey]
-                        if value == 'ahered':
-                            value = 'adhere'
-                        if value == 'violated':
-                            value = 'violate'
-                        if value == 'adhered_violated':
+                        if value in normValuesAdhere:
+                            value = normAdhere
+                        if value in normValuesViolate:
+                            value = normViolate
+                        if value in normValuesAdhereViolate:
                             columns = [
                                 key,
                                 videoname,
                                 f'{videoname}_{t["id"]:04}',
                                 normKey,
-                                'adhere',
+                                normAdhere,
                             ]
                             writer.writerow(columns)
                             columns = [
@@ -170,10 +180,12 @@ def export_norms_tab(folders, userMap, user):
                                 videoname,
                                 f'{videoname}_{t["id"]:04}',
                                 normKey,
-                                'violate',
+                                normViolate,
                             ]
                             writer.writerow(columns)
                         else:
+                            if normKey in normValuesNone:
+                                value = normNone
                             columns = [
                                 key,
                                 videoname,

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -343,7 +343,7 @@ def export_links_tab(url, folders):
             "Name",
             "LC",
             "CONDITION",
-            "SCENARIO"
+            "SCENARIO",
             "FLE",
             "SME",
             "DATE",

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -151,14 +151,39 @@ def export_norms_tab(folders, userMap, user):
                                 userDataFound[mapped][normMap[normKey]] = norms[normKey]
                 for key in userDataFound.keys():
                     for normKey in userDataFound[key].keys():
-                        columns = [
-                            key,
-                            videoname,
-                            f'{videoname}_{t["id"]:04}',
-                            normKey,
-                            userDataFound[key][normKey],
-                        ]
-                        writer.writerow(columns)
+                        value = userDataFound[key][normKey]
+                        if value == 'ahered':
+                            value = 'adhere'
+                        if value == 'violated':
+                            value = 'violate'
+                        if value == 'adhered_violated':
+                            columns = [
+                                key,
+                                videoname,
+                                f'{videoname}_{t["id"]:04}',
+                                normKey,
+                                'adhere',
+                            ]
+                            writer.writerow(columns)
+                            columns = [
+                                key,
+                                videoname,
+                                f'{videoname}_{t["id"]:04}',
+                                normKey,
+                                'violate',
+                            ]
+                            writer.writerow(columns)
+                        else:
+                            columns = [
+                                key,
+                                videoname,
+                                f'{videoname}_{t["id"]:04}',
+                                normKey,
+                                value,
+                            ]
+                            writer.writerow(columns)
+
+                        
     yield csvFile.getvalue()
     csvFile.seek(0)
     csvFile.truncate(0)

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -184,7 +184,7 @@ def export_norms_tab(folders, userMap, user):
                             ]
                             writer.writerow(columns)
                         else:
-                            if normKey in normValuesNone:
+                            if value in normValuesNone:
                                 value = normNone
                             columns = [
                                 key,


### PR DESCRIPTION
resolves #58

Norms can now both be adhered and violated.
Updated the export to reflect both of these exported values if they exist.
Also updated the export so it uses the properly formatted words of 'adhere' and 'violate' instead of 'adhered' and 'violated'
