### PR TITLE
UI Update Request

### DIFF
--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -80,20 +80,20 @@ export default defineComponent({
         return ['None'];
       }
       const root = [
+        'Admiration',
         'Apology',
         'Criticism',
-        'Greeting',
-        'Request',
-        'Persuasion',
-        'Thanks',
-        'Taking Leave',
-        'Admiration',
         'Finalizing Negotiating/Deal',
+        'Greeting',
+        'Persuasion',
         'Refusing a Request',
+        'Request',
+        'Taking Leave',
+        'Thanks',
       ];
       const normVariants = root
         .map((item) => [`${item} (adhered)`, `${item} (violated)`])
-        .reduce((acc, x) => acc.concat(x));
+        .reduce((acc, x) => acc.concat(x)).sort();
 
       return [
         'None',
@@ -691,7 +691,7 @@ export default defineComponent({
       <v-row dense>
         <v-col cols="11">
           <h3>
-            Norms
+            Social Norms
           </h3>
         </v-col>
         <v-col>

--- a/client/src/components/UMDChangepoint.vue
+++ b/client/src/components/UMDChangepoint.vue
@@ -65,6 +65,11 @@ export default defineComponent({
                   const attribute = feature.attributes[key];
                   const replaced = key.replace(`${userLogin.value}_`, '');
                   if (replaced === 'Impact') {
+                    changePointImpact.value = parseInt((attribute as string), 10) * 1000;
+                    changePointFrame.value = currentFrame;
+                    foundFeature = true;
+                  }
+                  if (replaced === 'ImpactV2.0') {
                     changePointImpact.value = parseInt((attribute as string), 10);
                     changePointFrame.value = currentFrame;
                     foundFeature = true;
@@ -127,6 +132,7 @@ export default defineComponent({
       if (track) {
         if (track.getFeature(changeData.frame)[0]) {
           track.removeFeatureAttribute(changeData.frame, `${userLogin.value}_Impact`);
+          track.removeFeatureAttribute(changeData.frame, `${userLogin.value}_ImpactV2.0`);
           track.removeFeatureAttribute(changeData.frame, `${userLogin.value}_Comment`);
         }
         if (selectedChangePoint.value === index) {
@@ -176,7 +182,8 @@ export default defineComponent({
           || !track.getFeature(changePointFrame.value)[0]?.keyframe) {
             track.toggleKeyframe(changePointFrame.value);
           }
-          track.setFeatureAttribute(changePointFrame.value, `${userLogin.value}_Impact`, changePointImpact.value);
+          track.removeFeatureAttribute(changePointFrame.value, `${userLogin.value}_Impact`);
+          track.setFeatureAttribute(changePointFrame.value, `${userLogin.value}_ImpactV2.0`, changePointImpact.value);
           track.setFeatureAttribute(changePointFrame.value, `${userLogin.value}_Comment`, changePointComment.value);
         }
         // save the file
@@ -363,18 +370,21 @@ export default defineComponent({
         </v-row>
         <v-form v-model="submitValid">
           <v-row>
+            <v-col cols="2">
+              Worse Outcome
+            </v-col>
             <v-col>
               <v-slider
                 v-model="changePointImpact"
-                label="Impact"
                 min="1"
-                max="5"
+                max="5000"
                 step="1"
-                ticks="always"
                 :rules="[v => v >= 0 || 'Set the Impact Value']"
                 required
-                :tick-size="10"
               />
+            </v-col>
+            <v-col cols="2">
+              Beter Outcome
             </v-col>
           </v-row>
           <v-row>

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -200,7 +200,7 @@ export default defineComponent({
         await video.play();
         data.playing = true;
         const segment = Math.floor((data.frame - 150) / 450);
-        if (props.mode && segment === maxSegment.value) {
+        if (['VAE', 'norms', 'emotion'].includes(props.mode) && segment === maxSegment.value) {
           pauseEndSegment = segment;
         }
 


### PR DESCRIPTION
- Put norms in the menu in alphabetical order
- Replace “Norms” with “Social Norms” above the menu
- change valence.tab to valence_arousal.tab
- The file_id and segment_id format should omit ‘Video’ and ‘.mp4’ (as they do in file_info.tab)
- Session_id.tab output multiple rows for the same session (because of multiple videos); please output only 1 session_id per session
- Prevent the automatic pausing of segments in Changepoint and Remediation Modes
- Update Changepoint Impact value to be a continuous slider (more resolution) than a 5 point slider
    - This requires updating outputs from older values and making sure that new values are on a higher resolution scale (1-5000)
    - There is now an attribute _ImpactV2.0 and the old attribute _Impact
    - The UI needs to convert the older value (1-5) to a (1-5000) value. Then on export if there is a new value it needs to be binned into a (1-5) value.