### PR TITLE
TA2 Annotation Wizard

### DIFF
--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -46,10 +46,8 @@ import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import context from 'dive-common/store/context';
 import ImageEnhancementsVue from 'vue-media-annotator/components/ImageEnhancements.vue';
 import RevisionHistoryVue from 'platform/web-girder/views/RevisionHistory.vue';
-import UMDAnnotationWrapper from 'vue-media-annotator/components/UMDAnnotationWrapper.vue';
 import { FormatTextRow, TextData } from 'vue-media-annotator/layers/AnnotationLayers/TextLayer';
 import { FrameDataTrack } from 'vue-media-annotator/layers/LayerTypes';
-import UMDTA2AnnotationWrapper from 'vue-media-annotator/components/UMDTA2AnnotationWrapper.vue';
 import GroupSidebarVue from './GroupSidebar.vue';
 import MultiCamToolsVue from './MultiCamTools.vue';
 import TypeThresholdVue from './TypeThreshold.vue';
@@ -604,21 +602,6 @@ export default defineComponent({
             component: GroupSidebarVue,
           });
         }
-        if (TA2Annotator.value) {
-          context.unregister({
-            component: UMDAnnotationWrapper,
-            description: 'UMD Annotator',
-          });
-          context.register({
-            component: UMDTA2AnnotationWrapper,
-            description: 'UMD TA2 Annotator',
-          });
-        } else {
-          context.unregister({
-            component: UMDTA2AnnotationWrapper,
-            description: 'UMD TA2 Annotator',
-          });
-        }
       } catch (err) {
         progress.loaded = false;
         console.error(err);
@@ -766,11 +749,7 @@ export default defineComponent({
 
 
     const handleAnnotatorToggle = () => {
-      if (!TA2Annotator.value) {
-        context.toggle('UMDAnnotationWrapper');
-      } else {
-        context.toggle('UMDTA2AnnotationWrapper');
-      }
+      context.toggle('UMDAnnotationWrapper');
     };
 
 

--- a/client/dive-common/store/context.ts
+++ b/client/dive-common/store/context.ts
@@ -7,7 +7,6 @@ import GroupSidebar from 'dive-common/components/GroupSidebar.vue';
 import AttributesSideBar from 'dive-common/components/AttributesSideBar.vue';
 import MultiCamTools from 'dive-common/components/MultiCamTools.vue';
 import UMDAnnotationWrapper from 'vue-media-annotator/components/UMDAnnotationWrapper.vue';
-import UMDTA2AnnotationWrapper from 'vue-media-annotator/components/UMDTA2AnnotationWrapper.vue';
 
 Vue.use(Install);
 
@@ -53,11 +52,6 @@ const componentMap: Record<string, ComponentMapItem> = {
     description: 'UMD Annotator',
     component: UMDAnnotationWrapper,
   },
-  [UMDTA2AnnotationWrapper.name]: {
-    description: 'UMD TA2 Annotator',
-    component: UMDTA2AnnotationWrapper,
-  },
-
 };
 
 function register(item: ComponentMapItem) {

--- a/client/package.json
+++ b/client/package.json
@@ -161,6 +161,7 @@
     "rules": {
       "no-underscore-dangle": 0,
       "spaced-comment": "off",
+      "max-len": "off",
       "no-useless-constructor": "off",
       "@typescript-eslint/no-useless-constructor": "error",
       "no-console": [

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -272,7 +272,7 @@ export default defineComponent({
         x-small
         color="primary"
         depressed
-        :to="{ name: 'viewer', params: { id: item._id } }"
+        :to="{ name: 'viewer', params: { id: item._id }, query : { mode: 'TA2Annotation' } }"
       >
         Launch TA2 Annotator
       </v-btn>

--- a/client/platform/web-girder/views/DataBrowser.vue
+++ b/client/platform/web-girder/views/DataBrowser.vue
@@ -43,7 +43,10 @@ export default defineComponent({
     }
 
     function isAnnotationFolder(item: GirderModel) {
-      return item._modelType === 'folder' && item.meta.annotate;
+      return item._modelType === 'folder' && item.meta.annotate && item.meta.UMDAnnotation !== 'TA2';
+    }
+    function isTA2Folder(item: GirderModel) {
+      return item._modelType === 'folder' && item.meta.annotate && item.meta.UMDAnnotation === 'TA2';
     }
 
     const shouldShowUpload = computed(() => (
@@ -94,6 +97,7 @@ export default defineComponent({
       copyLink,
       exportLinks,
       exportAnnotations,
+      isTA2Folder,
     };
   },
 });
@@ -262,6 +266,17 @@ export default defineComponent({
           mdi-content-copy
         </v-icon>
       </v-btn>
+      <v-btn
+        v-if="isTA2Folder(item)"
+        class="ml-2"
+        x-small
+        color="primary"
+        depressed
+        :to="{ name: 'viewer', params: { id: item._id } }"
+      >
+        Launch TA2 Annotator
+      </v-btn>
+
       <v-chip
         v-if="(item.foreign_media_id)"
         color="white"

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -76,8 +76,8 @@ export default defineComponent({
 
   setup(props, ctx) {
     const { prompt } = usePrompt();
-    const mode: Ref<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review'> = ref(
-      ctx.root.$route.query.mode as 'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review',
+    const mode: Ref<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review' | 'TA2Annotation'> = ref(
+      ctx.root.$route.query.mode as 'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review' | 'TA2Annotation',
     );
     const viewerRef = ref();
     const store = useStore();

--- a/client/src/components/UMDAnnotation.vue
+++ b/client/src/components/UMDAnnotation.vue
@@ -31,7 +31,7 @@ export default defineComponent({
       default: 500,
     },
     mode: {
-      type: String as PropType<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review'>,
+      type: String as PropType<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review' | 'TA2Annotation'>,
       default: 'review',
     },
   },

--- a/client/src/components/UMDAnnotationWrapper.vue
+++ b/client/src/components/UMDAnnotationWrapper.vue
@@ -7,6 +7,7 @@ import StackedVirtualSidebarContainer from 'dive-common/components/StackedVirtua
 import UMDAnnotation from './UMDAnnotation.vue';
 import UMDChangepoint from './UMDChangepoint.vue';
 import UMDRemediation from './UMDRemediation.vue';
+import UMDTA2Annotation from './UMDTA2Annotation.vue';
 
 export default defineComponent({
   name: 'UMDAnnotationWrapper',
@@ -16,6 +17,7 @@ export default defineComponent({
     UMDAnnotation,
     UMDChangepoint,
     UMDRemediation,
+    UMDTA2Annotation,
   },
   props: {
     width: {
@@ -23,7 +25,7 @@ export default defineComponent({
       default: 500,
     },
     mode: {
-      type: String as PropType<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review'>,
+      type: String as PropType<'VAE' | 'norms' | 'changepoint' | 'emotion' | 'remediation' | 'review' | 'TA2Annotation'>,
       default: 'review',
     },
   },
@@ -37,7 +39,7 @@ export default defineComponent({
 
 <template>
   <UMDAnnotation
-    v-if="!['changepoint', 'remediation'].includes(mode)"
+    v-if="!['changepoint', 'remediation', 'TA2Annotation'].includes(mode)"
     :mode="mode"
   />
   <UMDChangepoint
@@ -47,6 +49,9 @@ export default defineComponent({
   <UMDRemediation
     v-else-if="mode ==='remediation'"
     :mode="mode"
+  />
+  <UMDTA2Annotation
+    v-else-if="mode === 'TA2Annotation'"
   />
 </template>
 

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -95,9 +95,10 @@ export default defineComponent({
           targetLanguage: null,
           alerts: null,
           rephrase: null,
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          rephrase_translation: null,
         };
         const transKeys = Object.keys(transObject);
-        console.log(track.attributes);
         annotation.value = { };
         Object.keys(track.attributes).forEach((key) => {
           // Grab Translation root data
@@ -362,7 +363,7 @@ export default defineComponent({
       </v-row>
       <v-expansion-panels v-model="activePanel">
         <v-expansion-panel style="border: 1px solid white">
-          <v-expansion-panel-header><h3>Information</h3></v-expansion-panel-header>
+          <v-expansion-panel-header><h3>Translation</h3></v-expansion-panel-header>
           <v-expansion-panel-content>
             <UMDTA2Translation
               v-if="translationData"

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -16,7 +16,6 @@ import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import UMDTA2Translation, { TA2Translation } from './UMDTA2Translation.vue';
 
 
-type NormsObjectValues = Record<string, 'adhered' |'violated' | 'EMPTY_NA' | 'adhered_violated'>;
 
 export default defineComponent({
   name: 'UMDTA2Annotation',

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -14,7 +14,7 @@ import {
 } from 'vue-media-annotator/provides';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import UMDTA2Translation, { TA2Translation } from './UMDTA2Translation.vue';
-
+import UMDTA2AnnotationWizard, { TA2Annotation } from './UMDTA2AnnotationWizard.vue';
 
 
 export default defineComponent({
@@ -24,6 +24,7 @@ export default defineComponent({
     StackedVirtualSidebarContainer,
     TooltipBtn,
     UMDTA2Translation,
+    UMDTA2AnnotationWizard,
   },
 
   props: {
@@ -52,34 +53,9 @@ export default defineComponent({
 
     const activePanel = ref(0);
 
-    const normsSelected: Ref<string[]> = ref([]);
-    const baseNormsList = computed(() => {
-      if (normsSelected.value.includes('None')) {
-        return ['None'];
-      }
-      const root = [
-        'Admiration',
-        'Apology',
-        'Criticism',
-        'Finalizing Negotiating/Deal',
-        'Greeting',
-        'Persuasion',
-        'Refusing a Request',
-        'Request',
-        'Taking Leave',
-        'Thanks',
-      ];
-      const normVariants = root
-        .map((item) => [`${item} (adhered)`, `${item} (violated)`])
-        .reduce((acc, x) => acc.concat(x)).sort();
-
-      return [
-        'None',
-        ...normVariants,
-      ];
-    });
     const userLogin = ref('');
     const loadedAttributes = ref(false);
+    const annotation: Ref<TA2Annotation | null> = ref({});
 
     let framePlaying = -1;
     const seekBegin = () => {
@@ -126,34 +102,42 @@ export default defineComponent({
           if (transKeys.includes(key)) {
             transObject[key] = track.attributes[key];
           }
-          if (key.includes(userLogin.value)) {
+          if (key.includes(userLogin.value)) { // Get User Attributes
             const replaced = key.replace(`${userLogin.value}_`, '');
-            if (replaced === 'Valence' && props.mode === 'VAE') {
+            annotation.value = { };
+            if (replaced === 'ASRQuality') {
               if (loadValues) {
-                console.log('where we load data for attributes');
+                annotation.value.ASRQuality = track.attributes[key] as number;
               }
               hasAttributes = true;
             }
-            if (replaced === 'Norms' && props.mode === 'norms') {
+            if (replaced === 'MTQuality') {
               if (loadValues) {
-                // Norms saving
-                /*
-                normsObject.value = (track.attributes[key] as NormsObjectValues);
-                normsSelected.value = [];
-                Object.entries(normsObject.value).forEach(([normKey, val]) => {
-                  const adhered = `${normKey} (adhered)`;
-                  const violated = `${normKey} (violated)`;
-                  if (val.includes('adhered')) {
-                    normsSelected.value.push(adhered);
-                  }
-                  if (val.includes('violated')) {
-                    normsSelected.value.push(violated);
-                  }
-                  if (val.includes('noann') || val.includes('EMPTY_NA')) {
-                    normsSelected.value.push('None');
-                  }
-                });
-                */
+                annotation.value.MTQuality = track.attributes[key] as number;
+              }
+              hasAttributes = true;
+            }
+            if (replaced === 'AlertsQuality') {
+              if (loadValues) {
+                annotation.value.AlertsQuality = track.attributes[key] as number;
+              }
+              hasAttributes = true;
+            }
+            if (replaced === 'RephrasingQuality') {
+              if (loadValues) {
+                annotation.value.RephrasingQuality = track.attributes[key] as number;
+              }
+              hasAttributes = true;
+            }
+            if (replaced === 'DelayedRemediation') {
+              if (loadValues) {
+                annotation.value.DelayedRemediation = track.attributes[key] as boolean;
+              }
+              hasAttributes = true;
+            }
+            if (replaced === 'TA2Norms') {
+              if (loadValues) {
+                annotation.value.Norms = (track.attributes[key] as TA2Annotation['Norms']);
               }
               hasAttributes = true;
             }
@@ -239,7 +223,7 @@ export default defineComponent({
       return false;
     });
 
-    const submit = async () => {
+    const submit = async (data: TA2Annotation) => {
       // Need to get information and set it for the track attributes
       if (selectedTrackIdRef.value !== null) {
         const track = cameraStore.getPossibleTrack(selectedTrackIdRef.value);
@@ -247,9 +231,23 @@ export default defineComponent({
         if (track === undefined) {
           return;
         }
-        if (props.mode === 'norms' || props.mode === 'review') {
-          // Seting Norms value
-          //track.setAttribute(`${userLogin.value}_Norms`, normsObject.value);
+        if (data.ASRQuality !== undefined) {
+          track.setAttribute(`${userLogin.value}_ASRQuality`, data.ASRQuality);
+        }
+        if (data.MTQuality !== undefined) {
+          track.setAttribute(`${userLogin.value}_MTQuality`, data.ASRQuality);
+        }
+        if (data.AlertsQuality !== undefined) {
+          track.setAttribute(`${userLogin.value}_AlertsQuality`, data.ASRQuality);
+        }
+        if (data.RephrasingQuality !== undefined) {
+          track.setAttribute(`${userLogin.value}_RephrasingQuality`, data.ASRQuality);
+        }
+        if (data.DelayedRemediation !== undefined) {
+          track.setAttribute(`${userLogin.value}_DelayedRemediation`, data.ASRQuality);
+        }
+        if (data.Norms !== undefined) {
+          track.setAttribute(`${userLogin.value}_TA2Norms`, data.ASRQuality);
         }
         // save the file
         handler.save();
@@ -266,49 +264,8 @@ export default defineComponent({
       }
     };
     const changeTrack = (direction: -1 | 1) => {
-      if (selectedTrackIdRef.value === maxSegment.value) {
-        if (props.mode === 'norms') {
-          // Norms data
-          //dataStore.normsSelected = normsSelected.value;
-          //dataStore.normsObject = normsObject.value;
-        }
-      }
       handler.trackSelectNext(direction, true);
     };
-
-    // const syncNorms = (data: string[]) => {
-    //   const keys = Object.keys(normsObject.value);
-    //   for (let i = 0; i < keys.length; i += 1) {
-    //     if (!normsSelected.value.includes(keys[i])) {
-    //       delete normsObject.value[keys[i]];
-    //     }
-    //   }
-    //   if (data.includes('None')) {
-    //     normsObject.value.None = 'EMPTY_NA';
-    //   } else {
-    //     for (let i = 0; i < data.length; i += 1) {
-    //       let adhered = data[i].includes('(adhered)');
-    //       let violated = data[i].includes('(violated)');
-    //       const baseKey = data[i].replace('(adhered)', '').replace('(violated)', '').trim();
-    //       if (normsObject.value[baseKey]) {
-    //         const existing = normsObject.value[baseKey];
-    //         if (existing === 'adhered') {
-    //           adhered = true;
-    //         }
-    //         if (existing === 'violated') {
-    //           violated = true;
-    //         }
-    //       }
-    //       if (adhered && violated) {
-    //         normsObject.value[baseKey] = 'adhered_violated';
-    //       } else if (adhered) {
-    //         normsObject.value[baseKey] = 'adhered';
-    //       } else if (violated) {
-    //         normsObject.value[baseKey] = 'violated';
-    //       }
-    //     }
-    //   }
-    // };
 
     watch(() => frame.value, () => {
       if (framePlaying !== -1 && frame.value >= framePlaying) {
@@ -339,25 +296,15 @@ export default defineComponent({
 
     const normsValid = ref(false);
 
-    const submitValid = computed(() => {
-      if (props.mode === 'norms') {
-        return normsValid.value;
-      }
-      return false;
-    });
-
     return {
       alreadyAnnotated,
       hasPrevious,
       hasNext,
       selectedTrackIdRef,
-      baseNormsList,
-      normsSelected,
       frame,
       outsideSegment,
       loadedAttributes,
       normsValid,
-      submitValid,
       submit,
       changeTrack,
       seekBegin,
@@ -366,6 +313,7 @@ export default defineComponent({
       translationData,
       activePanel,
       //refs
+      annotation,
     };
   },
 });
@@ -421,7 +369,7 @@ export default defineComponent({
         </v-btn>
       </v-row>
       <v-expansion-panels v-model="activePanel">
-        <v-expansion-panel>
+        <v-expansion-panel style="border: 1px solid white">
           <v-expansion-panel-header><h3>Information</h3></v-expansion-panel-header>
           <v-expansion-panel-content>
             <UMDTA2Translation
@@ -431,11 +379,17 @@ export default defineComponent({
           </v-expansion-panel-content>
         </v-expansion-panel>
       </v-expansion-panels>
+      <v-row v-if="loadedAttributes || annotation">
+        <UMDTA2AnnotationWizard
+          :annotations="annotation"
+          :outside-segment="outsideSegment"
+        />
+      </v-row>
       <v-row>
         <v-col>
           <v-btn
             :color="loadedAttributes ? 'warning' : 'success'"
-            :disabled="outsideSegment || !submitValid"
+            :disabled="outsideSegment"
             @click="submit"
           >
             {{ loadedAttributes ? 'Update' : 'Submit' }}

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -188,7 +188,7 @@ export default defineComponent({
       seekBegin();
     };
     const initialize = async () => {
-      handler.setMaxSegment(0);
+      handler.setMaxSegment(99999);
       const user = await restClient.fetchUser();
       userLogin.value = user.login;
       if (selectedTrackIdRef.value === null) {
@@ -199,12 +199,6 @@ export default defineComponent({
     loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
     watch(selectedTrackIdRef, () => {
       loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
-      if (selectedTrackIdRef.value === maxSegment.value && !loadedAttributes.value) {
-        console.log('reloading datastore');
-      }
-      if (selectedTrackIdRef.value !== null) {
-        handler.setMaxSegment(selectedTrackIdRef.value);
-      }
     });
 
 

--- a/client/src/components/UMDTA2AnnotationWizard.vue
+++ b/client/src/components/UMDTA2AnnotationWizard.vue
@@ -3,9 +3,17 @@ import {
   defineComponent, PropType, ref, Ref,
 } from '@vue/composition-api';
 
-
-export type NormsList = 'Admiration' | 'Apology' | 'Criticism' | 'Finalizing Negotiating/Deal' | 'Greeting' | 'Persuasion' | 'Refusing a Request' | 'Request' | 'Taking Leave' | 'Thanks';
-
+export type NormsList =
+  | 'Admiration'
+  | 'Apology'
+  | 'Criticism'
+  | 'Finalizing Negotiating/Deal'
+  | 'Greeting'
+  | 'Persuasion'
+  | 'Refusing a Request'
+  | 'Request'
+  | 'Taking Leave'
+  | 'Thanks';
 
 export interface TA2NormStatus {
   status: 'adhered' | 'violated';
@@ -21,24 +29,30 @@ export interface TA2Annotation {
   Norms?: Record<NormsList, TA2NormStatus>;
 }
 
-
 export default defineComponent({
   name: 'UMDTA2AnnotationWizard',
 
-  components: {
-  },
+  components: {},
 
   props: {
     annotations: {
       type: Object as PropType<TA2Annotation>,
       required: true,
     },
+    outsideSegment: {
+      type: Boolean,
+      required: true,
+    },
   },
 
   setup(props, { emit }) {
     const annotationState: Ref<'ASRMTQuality' | 'Norms' | 'AlertRephrasing'> = ref('ASRMTQuality');
-    const steps = ref(['ASR/Translation Quality', 'Norm Adherence/Violation', 'Remediation Qaulity']);
-
+    const steps = ref([
+      'ASR/Translation Quality',
+      'Norm Adherence/Violation',
+      'Remediation Qaulity',
+    ]);
+    const stepper = ref(1);
     const ASRQuality = ref(0);
     const MTQuality = ref(0);
     const AlertsQuality = ref(0);
@@ -57,12 +71,11 @@ export default defineComponent({
       'Request',
       'Taking Leave',
       'Thanks',
-
-
     ]);
     return {
       annotationState,
       steps,
+      stepper,
       ASRQuality,
       MTQuality,
       Norms,
@@ -78,306 +91,334 @@ export default defineComponent({
 
 
 <template>
-  <v-stepper :items="steps">
-    <template v-slot:item.1>
-      <v-card
-        title="ASR/Translation Quality"
-        flat
+  <v-stepper
+    v-model="stepper"
+    style="width:100%"
+  >
+    <v-stepper-header>
+      <v-stepper-step
+        :complete="stepper > 1"
+        step="1"
       >
-        <v-row
-          dense
-          class="bottomborder"
-        >
-          <v-col>
-            <v-row dense>
-              <v-col cols="2">
-                ASR Quality
-              </v-col>
-              <v-col>
-                <v-slider
-                  v-model="ASRQuality"
-                  min="1"
-                  max="1000"
-                  step="1"
-                  dense
-                  persistent-hint
-                />
-              </v-col>
-              <v-col cols="1">
-                <v-tooltip
-                  open-delay="200"
-                  left
-                  max-width="300"
-                >
-                  <template #activator="{ on }">
-                    <v-icon
-                      v-on="on"
-                    >
-                      mdi-help
-                    </v-icon>
-                  </template>
-                  <p style="font-size:1.4em">
-                    Evaluation the ASR Quality
-                    <ul>
-                      <li>
-                        0= Very low quality, inadequate; overall gist of message and details may be very difficult to
-                        comprehend without relying on contextual clues.
-                      </li>
-                      <li>
-                        1= Tending toward low quality, but minimally adequate; overall gist of message and most
-                        details is comprehensible with some difficulty
-                      </li>
-                      <li>
-                        2= Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
-                        (interpretation) elements but mainly comprehensible
-                      </li>
-                      <li>
-                        3= Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
-                        ceiling condition interpretation).
-                      </li>
-                    </ul>
-                  </p>
-                </v-tooltip>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-        <v-row
-          dense
-          class="bottomborder"
-        >
-          <v-col>
-            <v-row dense>
-              <v-col cols="2">
-                MT Quality
-              </v-col>
-              <v-col>
-                <v-slider
-                  v-model="MTQuality"
-                  min="1"
-                  max="1000"
-                  step="1"
-                  dense
-                  persistent-hint
-                />
-              </v-col>
-              <v-col cols="1">
-                <v-tooltip
-                  open-delay="200"
-                  left
-                  max-width="300"
-                >
-                  <template #activator="{ on }">
-                    <v-icon
-                      v-on="on"
-                    >
-                      mdi-help
-                    </v-icon>
-                  </template>
-                  <p style="font-size:1.4em">
-                    Evaluation the Machine Translation Quality
-                    <ul>
-                      <li>
-                        0= Very low quality, inadequate; overall gist of message and details may be very difficult to
-                        comprehend without relying on contextual clues.
-                      </li>
-                      <li>
-                        1= Tending toward low quality, but minimally adequate; overall gist of message and most
-                        details is comprehensible with some difficulty
-                      </li>
-                      <li>
-                        2= Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
-                        (interpretation) elements but mainly comprehensible
-                      </li>
-                      <li>
-                        3= Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
-                        ceiling condition interpretation).
-                      </li>
-                    </ul>
-                  </p>
-                </v-tooltip>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-      </v-card>
-    </template>
+        ASR/MT
+      </v-stepper-step>
 
-    <template v-slot:item.2>
-      <v-card
-        title="Norm Adherence/Violation"
-        flat
+      <v-divider />
+
+      <v-stepper-step
+        :complete="stepper > 2"
+        step="2"
       >
-        <v-row>
-          <v-select
-            v-model="selectedNorms"
-            label="Norms"
-            multiple
-            items="baseNorms"
-            chips
-            clearable
-            deletable-chips
-          />
-        </v-row>
-        <v-list>
-          <v-list-item
-            v-for="(item,key) in Norms"
-            :key="key"
+        Norms
+      </v-stepper-step>
+
+      <v-divider />
+
+      <v-stepper-step step="3">
+        Remediation
+      </v-stepper-step>
+    </v-stepper-header>
+
+    <v-stepper-items>
+      <v-stepper-content step="1">
+        <v-card
+          title="ASR/Translation Quality"
+          flat
+        >
+          <v-row
+            dense
+            class="bottomborder"
           >
-            <v-select
-              v-if="item && item.status"
-              label="status"
-              :items="['adhered', 'violated']"
-              :value="item?.status"
-            />
-            <v-select
-              v-if="item && item.remediation"
-              :disabled="item && item.status === 'adhered'"
-              label="status"
-              :items="[
-                { title: 'Unnecessary', value: 0 },
-                { title: 'Recommended', value: 1 },
-                { title: 'Necessary', value: 2 },
-              ]"
-              :value="item?.status"
-            />
-          </v-list-item>
-        </v-list>
-      </v-card>
-    </template>
+            <v-col>
+              <v-row dense>
+                <v-col cols="2">
+                  ASR Quality
+                </v-col>
+                <v-col>
+                  <v-slider
+                    v-model="ASRQuality"
+                    min="1"
+                    max="1000"
+                    step="1"
+                    dense
+                    persistent-hint
+                  />
+                </v-col>
+                <v-col cols="1">
+                  <v-tooltip
+                    open-delay="200"
+                    left
+                    max-width="300"
+                  >
+                    <template #activator="{ on }">
+                      <v-icon
+                        v-on="on"
+                      >
+                        mdi-help
+                      </v-icon>
+                    </template>
+                    <p style="font-size:1.4em">
+                      Evaluation the ASR Quality
+                      <ul>
+                        <li>
+                          0: Very low quality, inadequate; overall gist of message and details may be very difficult to
+                          comprehend without relying on contextual clues.
+                        </li>
+                        <li>
+                          1: Tending toward low quality, but minimally adequate; overall gist of message and most
+                          details is comprehensible with some difficulty
+                        </li>
+                        <li>
+                          2: Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
+                          (interpretation) elements but mainly comprehensible
+                        </li>
+                        <li>
+                          3: Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
+                          ceiling condition interpretation).
+                        </li>
+                      </ul>
+                    </p>
+                  </v-tooltip>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+          <v-row
+            dense
+            class="bottomborder"
+          >
+            <v-col>
+              <v-row dense>
+                <v-col cols="2">
+                  MT Quality
+                </v-col>
+                <v-col>
+                  <v-slider
+                    v-model="MTQuality"
+                    min="1"
+                    max="1000"
+                    step="1"
+                    dense
+                    persistent-hint
+                  />
+                </v-col>
+                <v-col cols="1">
+                  <v-tooltip
+                    open-delay="200"
+                    left
+                    max-width="300"
+                  >
+                    <template #activator="{ on }">
+                      <v-icon
+                        v-on="on"
+                      >
+                        mdi-help
+                      </v-icon>
+                    </template>
+                    <p style="font-size:1.4em">
+                      Evaluation the Machine Translation Quality
+                      <ul>
+                        <li>
+                          0: Very low quality, inadequate; overall gist of message and details may be very difficult to
+                          comprehend without relying on contextual clues.
+                        </li>
+                        <li>
+                          1: Tending toward low quality, but minimally adequate; overall gist of message and most
+                          details is comprehensible with some difficulty
+                        </li>
+                        <li>
+                          2: Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
+                          (interpretation) elements but mainly comprehensible
+                        </li>
+                        <li>
+                          3: Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
+                          ceiling condition interpretation).
+                        </li>
+                      </ul>
+                    </p>
+                  </v-tooltip>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+        </v-card>
+      </v-stepper-content>
 
-    <template v-slot:item.3>
-      <v-card
-        title="Remediation Quality"
-        flat
-      >
-        <v-row
-          dense
-          class="bottomborder"
+      <v-stepper-content step="2">
+        <v-card
+          title="Norm Adherence/Violation"
+          flat
         >
-          <v-col>
-            <v-row dense>
-              <v-col cols="2">
-                Alerts Quality
-              </v-col>
-              <v-col>
-                <v-slider
-                  v-model="AlertsQuality"
-                  min="0"
-                  max="4"
-                  step="1"
-                  dense
-                  persistent-hint
-                />
-              </v-col>
-              <v-col cols="1">
-                <v-tooltip
-                  open-delay="200"
-                  left
-                  max-width="300"
-                >
-                  <template #activator="{ on }">
-                    <v-icon
-                      v-on="on"
-                    >
-                      mdi-help
-                    </v-icon>
-                  </template>
-                  <p style="font-size:1.4em">
-                    Evaluation the Alerts Quality
-                    <ul>
-                      <li>
-                        0= Alerts have a siginficant negative impact to the dialog by distracting the speaker or are categorically inaccurate
-                      </li>
-                      <li>
-                        1= Alerts have a slight negative impact by distracting the speaker or are slightly inaccurate.
-                      </li>
-                      <li>
-                        1000
-                      </li><li>
-                        3= Alerts help slightly, lead to a slightly more culturally appropriate utterance.
-                      </li>
-                      <li>
-                        4= Alerts have a significant positive impact on the dialog by generating accruate alerts that lead to significantly improved cultural appropriatenesss of the utterance.
-                      </li>
-                    </ul>
-                  </p>
-                </v-tooltip>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-        <v-row
-          dense
-          class="bottomborder"
+          <v-row>
+            <v-select
+              v-model="selectedNorms"
+              label="Norms"
+              multiple
+              :items="baseNorms"
+              chips
+              clearable
+              deletable-chips
+            />
+          </v-row>
+          <v-list v-if="Norms">
+            <v-list-item
+              v-for="(item,key) in Norms"
+              :key="key"
+            >
+              <v-select
+                v-if="item && item.status"
+                label="status"
+                :items="['adhered', 'violated']"
+                :value="item.status"
+              />
+              <v-select
+                v-if="item && item.remediation"
+                :disabled="item && item.status === 'adhered'"
+                label="status"
+                :items="[
+                  { title: 'Unnecessary', value: 0 },
+                  { title: 'Recommended', value: 1 },
+                  { title: 'Necessary', value: 2 },
+                ]"
+                :value="item.status"
+              />
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-stepper-content>
+
+      <v-stepper-content step="3">
+        <v-card
+          title="Remediation Quality"
+          flat
         >
-          <v-col>
-            <v-row dense>
-              <v-col cols="2">
-                Rephrasing Quality
-              </v-col>
-              <v-col>
-                <v-slider
-                  v-model="RephrasingQuality"
-                  min="0"
-                  max="4"
-                  step="1"
-                  dense
-                  persistent-hint
-                />
-              </v-col>
-              <v-col cols="1">
-                <v-tooltip
-                  open-delay="200"
-                  left
-                  max-width="300"
-                >
-                  <template #activator="{ on }">
-                    <v-icon
-                      v-on="on"
-                    >
-                      mdi-help
-                    </v-icon>
-                  </template>
-                  <p style="font-size:1.4em">
-                    Evaluation the Rephrasing Quality
-                    <ul>
-                      <li>
-                        0= Rephrasing has a significant negative impact to the dialog, resulting in little improvement in the
-                        cultural appropriateness of the utterance, introduces new or additional norm violations, or distorts the
-                        intended message unacceptably.
-                      </li>
-                      <li>
-                        1= Rephrasing has a slightly negative impact.
-                      </li>
-                      <li>
-                        2= Rephrasing is benign / basically has no impact.
-                      </li>
-                      <li>
-                        3= Rephrasing helps slightly
-                      </li>
-                      <li>
-                        4= Rephrasing has a significant positive impact on the dialog by making the utterance culturally
-                        appropriate, while staying loyal to the original meaning.
-                      </li>
-                    </ul>
-                  </p>
-                </v-tooltip>
-              </v-col>
-            </v-row>
-          </v-col>
-        </v-row>
-        <v-row>
-          <v-switch
-            v-model="DelayedRemediation"
-            label="Delayed Remediation"
-          />
-        </v-row>
-      </v-card>
-    </template>
+          <v-row
+            dense
+            class="bottomborder"
+          >
+            <v-col>
+              <v-row dense>
+                <v-col cols="2">
+                  Alerts Quality
+                </v-col>
+                <v-col>
+                  <v-slider
+                    v-model="AlertsQuality"
+                    min="0"
+                    max="4"
+                    step="1"
+                    dense
+                    persistent-hint
+                  />
+                </v-col>
+                <v-col cols="1">
+                  <v-tooltip
+                    open-delay="200"
+                    left
+                    max-width="300"
+                  >
+                    <template #activator="{ on }">
+                      <v-icon
+                        v-on="on"
+                      >
+                        mdi-help
+                      </v-icon>
+                    </template>
+                    <p style="font-size:1.4em">
+                      Evaluation the Alerts Quality
+                      <ul>
+                        <li>
+                          0: Alerts have a siginficant negative impact to the dialog by distracting the speaker or are categorically inaccurate
+                        </li>
+                        <li>
+                          1: Alerts have a slight negative impact by distracting the speaker or are slightly inaccurate.
+                        </li>
+                        <li>
+                          2: Alerts are benign/basically have no impact
+                        </li><li>
+                          3: Alerts help slightly, lead to a slightly more culturally appropriate utterance.
+                        </li>
+                        <li>
+                          4: Alerts have a significant positive impact on the dialog by generating accruate alerts that lead to significantly improved cultural appropriatenesss of the utterance.
+                        </li>
+                      </ul>
+                    </p>
+                  </v-tooltip>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+          <v-row
+            dense
+            class="bottomborder"
+          >
+            <v-col>
+              <v-row dense>
+                <v-col cols="2">
+                  Rephrasing Quality
+                </v-col>
+                <v-col>
+                  <v-slider
+                    v-model="RephrasingQuality"
+                    min="0"
+                    max="4"
+                    step="1"
+                    dense
+                    persistent-hint
+                  />
+                </v-col>
+                <v-col cols="1">
+                  <v-tooltip
+                    open-delay="200"
+                    left
+                    max-width="300"
+                  >
+                    <template #activator="{ on }">
+                      <v-icon
+                        v-on="on"
+                      >
+                        mdi-help
+                      </v-icon>
+                    </template>
+                    <p style="font-size:1.4em">
+                      Evaluation the Rephrasing Quality
+                      <ul>
+                        <li>
+                          0: Rephrasing has a significant negative impact to the dialog, resulting in little improvement in the
+                          cultural appropriateness of the utterance, introduces new or additional norm violations, or distorts the
+                          intended message unacceptably.
+                        </li>
+                        <li>
+                          1: Rephrasing has a slightly negative impact.
+                        </li>
+                        <li>
+                          2: Rephrasing is benign / basically has no impact.
+                        </li>
+                        <li>
+                          3: Rephrasing helps slightly
+                        </li>
+                        <li>
+                          4: Rephrasing has a significant positive impact on the dialog by making the utterance culturally
+                          appropriate, while staying loyal to the original meaning.
+                        </li>
+                      </ul>
+                    </p>
+                  </v-tooltip>
+                </v-col>
+              </v-row>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-switch
+              v-model="DelayedRemediation"
+              label="Delayed Remediation"
+            />
+          </v-row>
+        </v-card>
+      </v-stepper-content>
+    </v-stepper-items>
   </v-stepper>
 </template>
 
 <style scoped lang="scss">
-
 </style>

--- a/client/src/components/UMDTA2AnnotationWizard.vue
+++ b/client/src/components/UMDTA2AnnotationWizard.vue
@@ -118,13 +118,13 @@ export default defineComponent({
 
     const updateNorm = (norm: NormsList, field: 'status' | 'remediation', value: 'adhered' | 'violated' | number) => {
       if (field === 'status') {
-        if (Norms.value[norm]) {
-          Norms.value[norm].status = value as 'adhered' | 'violated';
+        if (Norms.value && Norms.value[norm] !== undefined) {
+          (Norms.value[norm] as TA2NormStatus).status = value as 'adhered' | 'violated';
         }
       }
       if (field === 'remediation') {
         if (Norms.value[norm]) {
-          Norms.value[norm].remediation = value as number;
+          (Norms.value[norm] as TA2NormStatus).remediation = value as number;
         }
       }
     };

--- a/client/src/components/UMDTA2AnnotationWizard.vue
+++ b/client/src/components/UMDTA2AnnotationWizard.vue
@@ -1,0 +1,383 @@
+<script lang="ts">
+import {
+  defineComponent, PropType, ref, Ref,
+} from '@vue/composition-api';
+
+
+export type NormsList = 'Admiration' | 'Apology' | 'Criticism' | 'Finalizing Negotiating/Deal' | 'Greeting' | 'Persuasion' | 'Refusing a Request' | 'Request' | 'Taking Leave' | 'Thanks';
+
+
+export interface TA2NormStatus {
+  status: 'adhered' | 'violated';
+  remediation: number; //0 -unecessary, 1 recommended, 2 necessary
+}
+
+export interface TA2Annotation {
+  ASRQuality?: number; //Quality number from 0-3
+  MTQuality?: number; // Quality number from 0-3
+  AlertsQuality?: number; // Quality number from 0-4
+  RephrasingQuality?: number; // Quality number from 0-4
+  DelayedRemediation?: boolean;
+  Norms?: Record<NormsList, TA2NormStatus>;
+}
+
+
+export default defineComponent({
+  name: 'UMDTA2AnnotationWizard',
+
+  components: {
+  },
+
+  props: {
+    annotations: {
+      type: Object as PropType<TA2Annotation>,
+      required: true,
+    },
+  },
+
+  setup(props, { emit }) {
+    const annotationState: Ref<'ASRMTQuality' | 'Norms' | 'AlertRephrasing'> = ref('ASRMTQuality');
+    const steps = ref(['ASR/Translation Quality', 'Norm Adherence/Violation', 'Remediation Qaulity']);
+
+    const ASRQuality = ref(0);
+    const MTQuality = ref(0);
+    const AlertsQuality = ref(0);
+    const RephrasingQuality = ref(0);
+    const DelayedRemediation = ref(false);
+    const Norms: Ref<Partial<Record<NormsList, TA2NormStatus>>> = ref({});
+    const selectedNorms: Ref<NormsList[]> = ref([]);
+    const baseNorms = ref([
+      'Admiration',
+      'Apology',
+      'Criticism',
+      'Finalizing Negotiating/Deal',
+      'Greeting',
+      'Persuasion',
+      'Refusing a Request',
+      'Request',
+      'Taking Leave',
+      'Thanks',
+
+
+    ]);
+    return {
+      annotationState,
+      steps,
+      ASRQuality,
+      MTQuality,
+      Norms,
+      baseNorms,
+      selectedNorms,
+      AlertsQuality,
+      RephrasingQuality,
+      DelayedRemediation,
+    };
+  },
+});
+</script>
+
+
+<template>
+  <v-stepper :items="steps">
+    <template v-slot:item.1>
+      <v-card
+        title="ASR/Translation Quality"
+        flat
+      >
+        <v-row
+          dense
+          class="bottomborder"
+        >
+          <v-col>
+            <v-row dense>
+              <v-col cols="2">
+                ASR Quality
+              </v-col>
+              <v-col>
+                <v-slider
+                  v-model="ASRQuality"
+                  min="1"
+                  max="1000"
+                  step="1"
+                  dense
+                  persistent-hint
+                />
+              </v-col>
+              <v-col cols="1">
+                <v-tooltip
+                  open-delay="200"
+                  left
+                  max-width="300"
+                >
+                  <template #activator="{ on }">
+                    <v-icon
+                      v-on="on"
+                    >
+                      mdi-help
+                    </v-icon>
+                  </template>
+                  <p style="font-size:1.4em">
+                    Evaluation the ASR Quality
+                    <ul>
+                      <li>
+                        0= Very low quality, inadequate; overall gist of message and details may be very difficult to
+                        comprehend without relying on contextual clues.
+                      </li>
+                      <li>
+                        1= Tending toward low quality, but minimally adequate; overall gist of message and most
+                        details is comprehensible with some difficulty
+                      </li>
+                      <li>
+                        2= Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
+                        (interpretation) elements but mainly comprehensible
+                      </li>
+                      <li>
+                        3= Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
+                        ceiling condition interpretation).
+                      </li>
+                    </ul>
+                  </p>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+        <v-row
+          dense
+          class="bottomborder"
+        >
+          <v-col>
+            <v-row dense>
+              <v-col cols="2">
+                MT Quality
+              </v-col>
+              <v-col>
+                <v-slider
+                  v-model="MTQuality"
+                  min="1"
+                  max="1000"
+                  step="1"
+                  dense
+                  persistent-hint
+                />
+              </v-col>
+              <v-col cols="1">
+                <v-tooltip
+                  open-delay="200"
+                  left
+                  max-width="300"
+                >
+                  <template #activator="{ on }">
+                    <v-icon
+                      v-on="on"
+                    >
+                      mdi-help
+                    </v-icon>
+                  </template>
+                  <p style="font-size:1.4em">
+                    Evaluation the Machine Translation Quality
+                    <ul>
+                      <li>
+                        0= Very low quality, inadequate; overall gist of message and details may be very difficult to
+                        comprehend without relying on contextual clues.
+                      </li>
+                      <li>
+                        1= Tending toward low quality, but minimally adequate; overall gist of message and most
+                        details is comprehensible with some difficulty
+                      </li>
+                      <li>
+                        2= Tending toward high quality, adequate; some inaccurate (ASR)/non-native (MT)/missing
+                        (interpretation) elements but mainly comprehensible
+                      </li>
+                      <li>
+                        3= Very high quality; equivalent to professional transcription (ASR)/ interpretation (MT and
+                        ceiling condition interpretation).
+                      </li>
+                    </ul>
+                  </p>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+      </v-card>
+    </template>
+
+    <template v-slot:item.2>
+      <v-card
+        title="Norm Adherence/Violation"
+        flat
+      >
+        <v-row>
+          <v-select
+            v-model="selectedNorms"
+            label="Norms"
+            multiple
+            items="baseNorms"
+            chips
+            clearable
+            deletable-chips
+          />
+        </v-row>
+        <v-list>
+          <v-list-item
+            v-for="(item,key) in Norms"
+            :key="key"
+          >
+            <v-select
+              v-if="item && item.status"
+              label="status"
+              :items="['adhered', 'violated']"
+              :value="item?.status"
+            />
+            <v-select
+              v-if="item && item.remediation"
+              :disabled="item && item.status === 'adhered'"
+              label="status"
+              :items="[
+                { title: 'Unnecessary', value: 0 },
+                { title: 'Recommended', value: 1 },
+                { title: 'Necessary', value: 2 },
+              ]"
+              :value="item?.status"
+            />
+          </v-list-item>
+        </v-list>
+      </v-card>
+    </template>
+
+    <template v-slot:item.3>
+      <v-card
+        title="Remediation Quality"
+        flat
+      >
+        <v-row
+          dense
+          class="bottomborder"
+        >
+          <v-col>
+            <v-row dense>
+              <v-col cols="2">
+                Alerts Quality
+              </v-col>
+              <v-col>
+                <v-slider
+                  v-model="AlertsQuality"
+                  min="0"
+                  max="4"
+                  step="1"
+                  dense
+                  persistent-hint
+                />
+              </v-col>
+              <v-col cols="1">
+                <v-tooltip
+                  open-delay="200"
+                  left
+                  max-width="300"
+                >
+                  <template #activator="{ on }">
+                    <v-icon
+                      v-on="on"
+                    >
+                      mdi-help
+                    </v-icon>
+                  </template>
+                  <p style="font-size:1.4em">
+                    Evaluation the Alerts Quality
+                    <ul>
+                      <li>
+                        0= Alerts have a siginficant negative impact to the dialog by distracting the speaker or are categorically inaccurate
+                      </li>
+                      <li>
+                        1= Alerts have a slight negative impact by distracting the speaker or are slightly inaccurate.
+                      </li>
+                      <li>
+                        1000
+                      </li><li>
+                        3= Alerts help slightly, lead to a slightly more culturally appropriate utterance.
+                      </li>
+                      <li>
+                        4= Alerts have a significant positive impact on the dialog by generating accruate alerts that lead to significantly improved cultural appropriatenesss of the utterance.
+                      </li>
+                    </ul>
+                  </p>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+        <v-row
+          dense
+          class="bottomborder"
+        >
+          <v-col>
+            <v-row dense>
+              <v-col cols="2">
+                Rephrasing Quality
+              </v-col>
+              <v-col>
+                <v-slider
+                  v-model="RephrasingQuality"
+                  min="0"
+                  max="4"
+                  step="1"
+                  dense
+                  persistent-hint
+                />
+              </v-col>
+              <v-col cols="1">
+                <v-tooltip
+                  open-delay="200"
+                  left
+                  max-width="300"
+                >
+                  <template #activator="{ on }">
+                    <v-icon
+                      v-on="on"
+                    >
+                      mdi-help
+                    </v-icon>
+                  </template>
+                  <p style="font-size:1.4em">
+                    Evaluation the Rephrasing Quality
+                    <ul>
+                      <li>
+                        0= Rephrasing has a significant negative impact to the dialog, resulting in little improvement in the
+                        cultural appropriateness of the utterance, introduces new or additional norm violations, or distorts the
+                        intended message unacceptably.
+                      </li>
+                      <li>
+                        1= Rephrasing has a slightly negative impact.
+                      </li>
+                      <li>
+                        2= Rephrasing is benign / basically has no impact.
+                      </li>
+                      <li>
+                        3= Rephrasing helps slightly
+                      </li>
+                      <li>
+                        4= Rephrasing has a significant positive impact on the dialog by making the utterance culturally
+                        appropriate, while staying loyal to the original meaning.
+                      </li>
+                    </ul>
+                  </p>
+                </v-tooltip>
+              </v-col>
+            </v-row>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-switch
+            v-model="DelayedRemediation"
+            label="Delayed Remediation"
+          />
+        </v-row>
+      </v-card>
+    </template>
+  </v-stepper>
+</template>
+
+<style scoped lang="scss">
+
+</style>

--- a/client/src/components/UMDTA2AnnotationWizard.vue
+++ b/client/src/components/UMDTA2AnnotationWizard.vue
@@ -159,6 +159,7 @@ export default defineComponent({
       <v-stepper-step
         :complete="stepper > 1"
         step="1"
+        editable
       >
         ASR/MT
       </v-stepper-step>
@@ -168,13 +169,17 @@ export default defineComponent({
       <v-stepper-step
         :complete="stepper > 2"
         step="2"
+        editable
       >
         Norms
       </v-stepper-step>
 
       <v-divider />
 
-      <v-stepper-step step="3">
+      <v-stepper-step
+        step="3"
+        editable
+      >
         Remediation
       </v-stepper-step>
     </v-stepper-header>

--- a/client/src/components/UMDTA2Translation.vue
+++ b/client/src/components/UMDTA2Translation.vue
@@ -10,8 +10,12 @@ export interface TA2Translation {
     translation: string;
     sourceLanguage: string;
     targetLanguage: string;
-    alerts?: { display: string }[];
+    alerts?: { display: string; delayed?: boolean }[];
     rephrase?: { display: string }[];
+    rephrase_translation?: {
+      translation: string;
+      sourceText: string;
+    }[];
 }
 
 export default defineComponent({
@@ -60,7 +64,13 @@ export default defineComponent({
         :key="`alert_${index}`"
         class="mx-2"
       >
-        <div><b>{{ index+1 }}.</b><span class="ml-2">{{ alert.display }}</span></div>
+        <div>
+          <b>{{ index+1 }}.</b><span class="ml-2"><v-chip
+            v-if="alert.delayed"
+            color="warning"
+            class="mx-2"
+          >Delayed</v-chip>{{ alert.display }}</span>
+        </div>
       </v-row>
     </p>
     <h3 v-if="data.rephrase">
@@ -73,6 +83,30 @@ export default defineComponent({
         class="mx-2"
       >
         <div><b>{{ index+1 }}.</b><span class="ml-2">{{ alert.display }}</span></div>
+      </v-row>
+    </p>
+    <h3 v-if="data.rephrase_translation">
+      Additional Translations
+    </h3>
+    <p v-if="data.rephrase_translation">
+      <v-row
+        v-for="(rephrase, index) in data.rephrase_translation"
+        :key="`rephrase_translation_${index}`"
+        class="mx-2"
+      >
+        <b>{{ index+1 }}.</b>
+        <v-container class="mx-5">
+          <v-row>
+            <div class="ml-2">
+              <b class="mr-2">Source Text:</b>{{ rephrase.sourceText }}
+            </div>
+          </v-row>
+          <v-row>
+            <div class="ml-2">
+              <b class="mr-2">Translation:</b>{{ rephrase.translation }}
+            </div>
+          </v-row>
+        </v-container>
       </v-row>
     </p>
   </div>

--- a/client/src/components/annotators/VideoAnnotator.vue
+++ b/client/src/components/annotators/VideoAnnotator.vue
@@ -153,7 +153,7 @@ export default defineComponent({
       video.currentTime = data.currentTime;
       data.frame = requestedFrame;
       data.flick = Math.round(data.currentTime * Flick);
-      if (!['changepoint', 'remediation'].includes(props.mode)) {
+      if (!['changepoint', 'remediation', 'TA2Annotation'].includes(props.mode)) {
         props.updateTime(data);
       } else if (data.frame < data.maxFrame) {
         const update = { frame: requestedFrame, flick: Math.round(data.currentTime * Flick) };
@@ -187,7 +187,7 @@ export default defineComponent({
         const updateData: {frame: number; flick: number; maxSegment?: number} = {
           frame: data.frame, flick: data.flick,
         };
-        if (['changepoint', 'remediation'].includes(props.mode)) {
+        if (['changepoint', 'remediation', 'TA2Annotation'].includes(props.mode)) {
           updateData.maxSegment = segment;
         }
         props.updateTime(updateData);

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -1,7 +1,7 @@
 import json
 import base64
 import click
-
+import string
 normMap = {
     '101': "Apology",
     '102': "Criticism",
@@ -17,8 +17,32 @@ normMap = {
 }
 
 
+def preprocess_text(text):
+    # Remove punctuation and convert to lowercase
+    text = text.translate(str.maketrans('', '', string.punctuation)).lower()
+    # Split the text into words
+    words = text.split()
+    return words
+
+
+def calculate_similarity(text1, text2):
+    # Preprocess both texts
+    words1 = preprocess_text(text1)
+    words2 = preprocess_text(text2)
+
+    # Calculate intersection of words
+    intersection = len(set(words1) & set(words2))
+    # Calculate union of words
+    union = len(set(words1) | set(words2))
+
+    # Calculate Jaccard similarity coefficient
+    similarity_score = intersection / union if union > 0 else 0
+
+    return similarity_score
+
 def remove_base64_from_jsonl(input_file, output_file):
     output = []
+    raw = []
     with open(input_file, 'r') as infile, open(output_file, 'w') as outfile:
         for line in infile:
             if not line.strip().startswith('#'):  # Skip lines starting with #
@@ -45,7 +69,10 @@ def remove_base64_from_jsonl(input_file, output_file):
                         if data['message']['type'] == 'norm_occurrence' and data['message']['name']:
                             if normMap[str(data['message']['name'])]:
                                 data['message']['norm'] = normMap[str(data['message']['name'])]
+                raw.append(data)                    
                 output.append(data)
+        with open('raw.json', 'w') as rawout:
+            json.dump(raw, rawout, ensure_ascii=False, indent=True)  # ensure_ascii=False to output UTF-8 properly
         json.dump(output, outfile, ensure_ascii=False, indent=True)  # ensure_ascii=False to output UTF-8 properly
         outfile.write('\n')
         return output
@@ -67,6 +94,7 @@ def create_or_get_turn(turns, start_time, end_time):
 def process_outputjson(output):
     turns = []
     print('processing output file')
+    translations = []
     for item in output:
         # we have a turn with ASR information
         if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TURN' and item.get('message', {}).get('type', False) == 'asr_result':
@@ -82,6 +110,18 @@ def process_outputjson(output):
                 'speaker': item['message']['speaker'],
                 'text': item['message']['translation'],
             }
+        # translation of possible Rephrasing
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TEXT' and item.get('message', {}).get('type', False) == 'translation':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'])
+            if turn.get('rephrase_translation', None) is None:
+                turn['rephrase_translation'] = []
+            turn['rephrase_translation'].append({
+                'source_language': item['message']['source_language'],
+                'target_language': item['message']['target_language'],
+                'speaker': item['message']['speaker'],
+                'text': item['message']['translation'],
+                'sourceText': item['message']['text'],
+            })
         # storing emotions for future use
         if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TURN' and item.get('message', {}).get('type', False) == 'sri_emotions':
             turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'])
@@ -122,20 +162,24 @@ def process_outputjson(output):
         if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'arousal':
             turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'])
             turn['arousal'] = item['message']['level']
-        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and item.get('message', {}).get('prefix', False) == 'alert':
+        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and (item.get('message', {}).get('prefix', False) == 'alert' or item.get('message', {}).get('prefix', False) == 'late') :
             turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'])
             if turn.get('actions', None) is None:
                 turn['actions'] = []
-            turn['actions'].append({
-                'display': item['message']['display'],
-            })
-        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and 'Rephrased:' in item.get('message', {}).get('display', ''):
+            message = item['message']['display'].replace('<i>', '').replace('</i>', '')
+            if not any(d.get('display', False) == message for d in turn['actions']):
+                turn['actions'].append({
+                    'display': message,
+                    'delayed': item.get('message', {}).get('prefix', False) == 'late'
+                })
+        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and (item.get('message', {}).get('remediation', False) == 'Auto' or 'Added:' in item.get('message', {}).get('display', '')):
             turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'])
             if turn.get('rephrase', None) is None:
                 turn['rephrase'] = []
-            turn['rephrase'].append({
-                'display': item['message']['display'],
-            })
+            if not any(d.get('display', False) == item['message']['display'] for d in turn['rephrase']):
+                turn['rephrase'].append({
+                    'display': item['message']['display'],
+                })
 
     output = []
     for item in turns:
@@ -205,6 +249,17 @@ def convert_output_to_tracks(output, width=1920, height=1080, framerate=30, offs
             track['attributes']['translation'] = translation
             track['attributes']['sourceLanguage'] = sourceLanguage
             track['attributes']['targetLanguage'] = targetLanguage
+        if item.get('rephrase_translation', False):
+            track['attributes']['rephrase_translation'] = []
+            for rehprase_translation in item['rephrase_translation']:
+                translation = rehprase_translation['text']
+                sourceText = rehprase_translation['sourceText']
+                if not any(d.get('translation') == translation for d in track['attributes']['rephrase_translation']):
+                    track['attributes']['rephrase_translation'].append({
+                        "translation": translation,
+                        "sourceText": sourceText,
+                    })
+
         emotions = None
         if item.get('emotions', False):
             emotions = item['emotions']

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -196,8 +196,8 @@ def convert_output_to_tracks(output, width=1920, height=1080, framerate=30, offs
         start_frame = offset_frames + (framerate * item['startTime'])
         end_frame = offset_frames + (framerate * item['endTime'])
         track = {
-            "begin": start_frame,
-            "end":end_frame,
+            "begin": int(start_frame),
+            "end": int(end_frame),
             "id": count,
             "confidencePairs": [
                 [
@@ -212,7 +212,7 @@ def convert_output_to_tracks(output, width=1920, height=1080, framerate=30, offs
             },
             "features": [
                 {
-                    "frame": start_frame,
+                    "frame": int(start_frame),
                     "bounds": [
                         0,
                         0,
@@ -224,7 +224,7 @@ def convert_output_to_tracks(output, width=1920, height=1080, framerate=30, offs
                     "attributes": {}
                 },
                                 {
-                    "frame": end_frame,
+                    "frame": int(end_frame),
                     "bounds": [
                         0,
                         0,


### PR DESCRIPTION
resolves #97 

TODO:

- [x] Add the advancement jumping between steps in the annotation
- [x] Connect submitting a step to saving the annotations automatically
- [x] Make it so it can load up previous annotations and automatically update when jumping between turns.
- [x] Test saving and loading values properly for different turns in the system
- [x] Add in Delayed Remediation Dispaly notes to the system.  Uses the `"type": "hololens"` Hololens action with `"remediation": "Lagging"` and `"prefix": "late"`
- [x] Extract rephrased translation from the file and provide that information when there is an alert for remediation
- [x] Make it so there is a marker for TA2 annotations and the opening has a prop much like VAE/Norms and other modes.
- [x] Remove the limit for seeking in the system, follow the changepoint/remediation format
- [x] Create the final display that removes the other visualization tools like the other annotation formats.