### PR TITLE
TA2 Upload Script + Turn Creation

### DIFF
--- a/client/dive-common/components/SidebarContext.vue
+++ b/client/dive-common/components/SidebarContext.vue
@@ -12,6 +12,10 @@ export default defineComponent({
       type: String,
       default: undefined,
     },
+    name: {
+      type: String,
+      default: undefined,
+    },
   },
   setup(props) {
     const options = computed(() => Object.entries(context.componentMap).map(([value, entry]) => ({

--- a/client/dive-common/components/Viewer.vue
+++ b/client/dive-common/components/Viewer.vue
@@ -737,7 +737,7 @@ export default defineComponent({
         editing: editingMode.value,
         type: annotation.styleType[0],
         confidence: 1,
-        text: `Segment ${annotation.track.id}`,
+        text: props.mode && props.mode.includes('TA2Annotation') ? `Turn ${annotation.track.id + 1}` : `Segment ${annotation.track.id}`,
         x: 100,
         y: 55,
       },

--- a/client/dive-common/use/useModeManager.ts
+++ b/client/dive-common/use/useModeManager.ts
@@ -796,6 +796,9 @@ export default function useModeManager({
       );
       const { flick, frameSize } = aggregateController.value;
       const newbounds: RectBounds = [0, 0, frameSize.value[0], frameSize.value[1]];
+      Object.entries(track.attributes).forEach(([key, val]) => {
+        newTrack.setAttribute(key, val);
+      });
       newTrack.setFeature({
         frame: track.begin,
         flick: flick.value,

--- a/client/platform/web-girder/views/ViewerLoader.vue
+++ b/client/platform/web-girder/views/ViewerLoader.vue
@@ -218,12 +218,15 @@ export default defineComponent({
       </template>
     </template>
     <template #right-sidebar>
-      <SidebarContext :mode="mode">
+      <SidebarContext
+        :mode="mode"
+      >
         <template #default="{ name, subCategory }">
           <component
             :is="name"
             :sub-category="subCategory"
             :mode="mode"
+            :name="viewerRef.datasetName"
             @update:revision="routeRevision"
           />
         </template>

--- a/client/src/components/UMDAnnotationWrapper.vue
+++ b/client/src/components/UMDAnnotationWrapper.vue
@@ -31,6 +31,10 @@ export default defineComponent({
       type: String as PropType<UMDAnnotationMode>,
       default: 'review',
     },
+    name: {
+      type: String,
+      default: undefined,
+    },
   },
   setup() {
     return {
@@ -61,6 +65,7 @@ export default defineComponent({
   <UMDTA2Annotation
     v-else-if="mode.includes('TA2Annotation')"
     :mode="mode"
+    :name="name"
   />
 </template>
 

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -37,6 +37,10 @@ export default defineComponent({
       type: String as PropType<UMDAnnotationMode>,
       default: 'TA2Annotation_ASRMTQuality',
     },
+    name: {
+      type: String,
+      default: undefined,
+    },
   },
 
   setup(props, { emit }) {
@@ -58,6 +62,23 @@ export default defineComponent({
     const loadedAttributes = ref(false);
     const annotation: Ref<TA2Annotation | null> = ref({});
 
+    const LCName = computed(() => {
+      if (props.name) {
+        if (props.name.includes('LC1')) {
+          return 'LC1';
+        }
+        if (props.name.includes('LC2')) {
+          return 'LC2';
+        }
+        if (props.name.includes('LC2')) {
+          return 'LC1';
+        }
+        if (props.name.includes('LC3')) {
+          return 'LC3';
+        }
+      }
+      return 'LC1';
+    });
     const seekBegin = () => {
       if (selectedTrackIdRef.value !== null) {
         const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
@@ -293,6 +314,7 @@ export default defineComponent({
       activePanel,
       //refs
       annotation,
+      LCName,
     };
   },
 });
@@ -362,7 +384,9 @@ export default defineComponent({
         <UMDTA2AnnotationWizard
           :annotations="annotation"
           :outside-segment="outsideSegment"
+          :l-c="LCName"
           :mode="mode"
+          :name="name"
           @save="submit($event)"
           @next-turn="changeTrack(1)"
         />

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -43,7 +43,7 @@ export default defineComponent({
     const selectedTrackIdRef = useSelectedTrackId();
 
     const { prompt } = usePrompt();
-    const { frame, maxSegment } = useTime();
+    const { frame } = useTime();
     const handler = useHandler();
     const restClient = useGirderRest();
     const cameraStore = useCameraStore();
@@ -58,7 +58,6 @@ export default defineComponent({
     const loadedAttributes = ref(false);
     const annotation: Ref<TA2Annotation | null> = ref({});
 
-    let framePlaying = -1;
     const seekBegin = () => {
       if (selectedTrackIdRef.value !== null) {
         const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
@@ -75,7 +74,6 @@ export default defineComponent({
       if (selectedTrackIdRef.value !== null) {
         const track = cameraStore.getAnyTrack(selectedTrackIdRef.value);
         handler.replayFromFrame(track.begin);
-        framePlaying = track.end;
       }
     };
 

--- a/client/src/components/UMDTA2AnnotationCreator.vue
+++ b/client/src/components/UMDTA2AnnotationCreator.vue
@@ -1,20 +1,19 @@
 <script lang="ts">
 import {
-  computed, defineComponent, ref, Ref, watch, PropType, onMounted,
+  computed, defineComponent, watch, onMounted,
 } from '@vue/composition-api';
 
 import TooltipBtn from 'vue-media-annotator/components/TooltipButton.vue';
 import StackedVirtualSidebarContainer from 'dive-common/components/StackedVirtualSidebarContainer.vue';
-import { useGirderRest } from 'platform/web-girder/plugins/girder';
 import {
   useCameraStore,
   useHandler,
   useSelectedTrackId,
   useTime,
 } from 'vue-media-annotator/provides';
-import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { clientSettings } from 'dive-common/store/settings';
 import { cloneDeep } from 'lodash';
+import { AnnotationId } from 'vue-media-annotator/BaseAnnotation';
 
 
 export default defineComponent({
@@ -32,13 +31,11 @@ export default defineComponent({
     },
   },
 
-  setup(props, { emit }) {
+  setup() {
     const selectedTrackIdRef = useSelectedTrackId();
 
-    const { prompt } = usePrompt();
     const { frame, maxSegment } = useTime();
     const handler = useHandler();
-    const restClient = useGirderRest();
     const cameraStore = useCameraStore();
 
     const firstTrack = cameraStore.getAnyPossibleTrack(0);
@@ -72,7 +69,6 @@ export default defineComponent({
 
     const initialize = async () => {
       handler.setMaxSegment(99999);
-      const user = await restClient.fetchUser();
     };
     onMounted(() => initialize());
 
@@ -140,43 +136,59 @@ export default defineComponent({
       return null;
     });
 
-    const reOrderTracks = () => {
+    const reOrderTracks = (newTrackId: AnnotationId) => {
       const tracks = cameraStore.sortedTracks;
       const trackCopy = cloneDeep(tracks.value);
       trackCopy.sort((a, b) => a.begin - b.begin);
+      let updatedTrackId = -1;
       // Now we have a sorted list by the begin point instead of the trackId.
       // So we need to update the tracks so they have the proper begin/end times
+      const trackIds = cameraStore.sortedTracks.value.map((item) => item.id);
+      handler.trackSelect(null, false);
+      handler.removeTrack(trackIds, true);
       trackCopy.forEach((item, index) => {
-        const getTrack = cameraStore.getTrack(index);
-        if (getTrack) {
-          const updateBeginFeature = item.getFeature(item.begin);
-          if (updateBeginFeature[0]) {
-            getTrack.deleteFeature(getTrack.begin);
-            getTrack.setFeature(updateBeginFeature[0]);
-          }
-          const updateEndFeature = item.getFeature(item.end);
-          if (updateEndFeature[0]) {
-            getTrack.deleteFeature(getTrack.end);
-            getTrack.setFeature(updateEndFeature[0]);
-          }
+        // eslint-disable-next-line no-param-reassign
+        item.id = index;
+        if (item.id !== index && item.id === newTrackId) {
+          updatedTrackId = index;
         }
+        handler.addReplacementTrack(item);
       });
-      // Now tracks should be reordered with their proper numbers
+      if (newTrackId !== -1) {
+        handler.trackSelect(newTrackId, false);
+      }
+      return updatedTrackId;
     };
 
     const createTurn = () => {
       const trackId = handler.addFullFrameTrack('turn', 100);
       if (trackId !== null) {
         handler.trackSelect(trackId, false);
-        reOrderTracks();
+        const updatedTrackId = reOrderTracks(trackId);
+        if (updatedTrackId === -1) {
+          handler.trackSelectNext(1);
+        } else {
+          handler.trackSelect(updatedTrackId, false);
+        }
+        handler.save();
+      }
+    };
+    const deleteTurn = () => {
+      if (selectedTrackIdRef.value !== null) {
+        handler.removeTrack([selectedTrackIdRef.value], true);
+        reOrderTracks(selectedTrackIdRef.value);
+        handler.trackSelectNext(-1);
         handler.save();
       }
     };
     const setFrame = (pos: 'begin' | 'end') => {
       if (selectedTrackIdRef.value !== null) {
+        const baseId = selectedTrackIdRef.value;
         handler.updateFullFrame(selectedTrackIdRef.value, pos);
-        reOrderTracks();
-        handler.trackSelect(selectedTrackIdRef.value, false);
+        reOrderTracks(selectedTrackIdRef.value);
+        if (baseId) {
+          handler.trackSelect(baseId, false);
+        }
         handler.save();
       }
     };
@@ -193,6 +205,7 @@ export default defineComponent({
       seekEnd,
       playSegment,
       createTurn,
+      deleteTurn,
       setFrame,
     };
   },
@@ -257,16 +270,26 @@ export default defineComponent({
         >
           Create Turn
         </v-btn>
+        <v-btn
+          v-if="selectedTrackIdRef !== null"
+          color="primary"
+          class="mx-2"
+          @click="deleteTurn()"
+        >
+          Delete Turn
+          <v-icon>mdi-delete</v-icon>
+        </v-btn>
       </v-row>
       <v-row v-if="trackFrames">
         <v-col><div><span>Begin Frame:</span><span>{{ trackFrames.begin }}</span></div></v-col>
         <v-col><div><span>End Frame:</span><span>{{ trackFrames.end }}</span></div></v-col>
       </v-row>
-      <v-row v-if="selectedTrackIdRef !== null">
+      <v-row v-if="selectedTrackIdRef !== null && trackFrames">
         <v-col>
           <v-btn
             color="primary"
             class="mx-2"
+            :disabled="frame > trackFrames.end"
             @click="setFrame('begin')"
           >
             Set Begin Frame
@@ -276,6 +299,7 @@ export default defineComponent({
           <v-btn
             color="primary"
             class="mx-2"
+            :disabled="frame < trackFrames.begin"
             @click="setFrame('end')"
           >
             Set End Frame

--- a/client/src/components/UMDTA2AnnotationWrapper.vue
+++ b/client/src/components/UMDTA2AnnotationWrapper.vue
@@ -21,6 +21,10 @@ export default defineComponent({
     mode: {
       default: 'review',
     },
+    name: {
+      type: String,
+      default: undefined,
+    },
   },
   setup() {
     return {

--- a/client/src/provides.ts
+++ b/client/src/provides.ts
@@ -19,6 +19,7 @@ import type { ImageEnhancements } from './use/useImageEnhancements';
 import TrackFilterControls from './TrackFilterControls';
 import GroupFilterControls from './GroupFilterControls';
 import CameraStore from './CameraStore';
+import Track from './track';
 
 
 /**
@@ -116,6 +117,7 @@ export interface Handler {
   trackAdd(): AnnotationId;
   /* update Rectangle bounds for track */
   addFullFrameTrack(type: string, width: number): AnnotationId | null;
+  addReplacementTrack(track: Track): void;
   updateFullFrame(trackId: AnnotationId, pos: 'begin' | 'end'): void;
   updateRectBounds(
     frameNum: number,
@@ -193,6 +195,7 @@ function dummyHandler(handle: (name: string, args: unknown[]) => void): Handler 
     trackSplit(...args) { handle('trackSplit', args); },
     trackAdd(...args) { handle('trackAdd', args); return 0; },
     addFullFrameTrack(...args) { handle('addFullFrameTrack', args); return null; },
+    addReplacementTrack(...args) { handle('addReplacementTrack', args); return null; },
     updateFullFrame(...args) { handle('updateFullFrame', args); },
     updateRectBounds(...args) { handle('updateRectBounds', args); },
     updateGeoJSON(...args) { handle('updateGeoJSON', args); },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4876,9 +4876,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001271:
-  version "1.0.30001521"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz"
-  integrity sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==
+  version "1.0.30001614"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz"
+  integrity sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/scripts/JSONLConverter.py
+++ b/scripts/JSONLConverter.py
@@ -13,6 +13,12 @@ normMap = {
     '108': "Admiration",
     '109': "Finalizing Negotiation/Deal",
     '110': "Refusing a Request",
+    '111': "Requesting Information",
+    '112': "Granting a Request",
+    '113': "Disagreement",
+    '114': "Respond to Request for Information",
+    '115': "Acknowledging Thanks",
+    '116': "Interrupting",
     "none": "None",
 }
 

--- a/scripts/cloneAndConvert.py
+++ b/scripts/cloneAndConvert.py
@@ -69,9 +69,11 @@ def get_matching_items(video_dict, item_dict):
 def download_and_process_json(gc: girder_client.GirderClient, itemId, name):
     if not os.path.exists(processingDirectory):
         os.mkdir(processingDirectory)
-    gc.downloadItem(itemId, os.path.join(processingDirectory, name), name=name)
+    gc.downloadItem(itemId, processingDirectory)
     # next we need to process the downloaded file and convert it into a track json
-    turns = process_outputjson(os.path.join(processingDirectory, name))
+    with open(f"{processingDirectory}/log_{name.replace('.json', '_converted.json')}", 'r') as f:
+        turns_output = json.load(f)
+    turns = process_outputjson(turns_output)
     trackJSON = convert_output_to_tracks(turns)
     if not os.path.exists(tracksDirectory):
         os.mkdir(tracksDirectory)
@@ -104,7 +106,7 @@ def run_script():
         item = matching[key]
         trackJSONFilePath = download_and_process_json(gc, item["jsonId"], f"{key}.json")
         item["trackJSON"] = trackJSONFilePath
-        cloneId = clone_video_folder(gc, item["videoId"], CloneDestinationFolderId)
+        cloneId = clone_video_folder(gc, item["videoId"], key, CloneDestinationFolderId)
         item["cloneId"] = cloneId
         upload_track_json(gc, cloneId, trackJSONFilePath)
         count += 1

--- a/scripts/cloneAndConvert.py
+++ b/scripts/cloneAndConvert.py
@@ -15,6 +15,12 @@ normMap = {
     '108': "Admiration",
     '109': "Finalizing Negotiation/Deal",
     '110': "Refusing a Request",
+    '111': "Requesting Information",
+    '112': "Granting a Request",
+    '113': "Disagreement",
+    '114': "Respond to Request for Information",
+    '115': "Acknowledging Thanks",
+    '116': "Interrupting",
     "none": "None",
 }
 

--- a/scripts/cloneAndConvert.py
+++ b/scripts/cloneAndConvert.py
@@ -1,7 +1,7 @@
 import girder_client
 import json
 import click
-import certifi
+import requests
 
 
 
@@ -12,9 +12,11 @@ CloneDestinationFolderId = ""
 apiURL = "annotation.umd.edu"
 
 def login():
-    gc = girder_client.GirderClient(apiURL, port=443, apiRoot='girder/api/v1')
-    gc.authenticate(interactive=True)
-    return gc
+    gc = girder_client.GirderClient(apiURL, port=443, apiRoot='girder/api/v1' )
+    with gc.session() as session:
+        session.verify = False
+        gc.authenticate(interactive=True)
+        return gc
 
 
 def getFolderList(gc: girder_client.GirderClient, folderId, parentType = "folder"):
@@ -36,7 +38,6 @@ def get_processVideos(gc, folderId):
 
 @click.command(name="removeDups", help="Load in ")
 def run_script():
-    print(certifi.where())
     gc = login()
     VideoList = getFolderList(gc, VideoSourceFolderId)
 

--- a/scripts/cloneAndConvert.py
+++ b/scripts/cloneAndConvert.py
@@ -21,6 +21,7 @@ def login():
 
 def getFolderList(gc: girder_client.GirderClient, folderId, parentType = "folder"):
     folders = list(gc.listFolder(folderId, parentFolderType=parentType))
+    print(folders)
     return folders
 
 def get_processVideos(gc, folderId):

--- a/scripts/cloneAndConvert.py
+++ b/scripts/cloneAndConvert.py
@@ -2,49 +2,337 @@ import girder_client
 import json
 import click
 import requests
+import os
 
+normMap = {
+    '101': "Apology",
+    '102': "Criticism",
+    '103': "Greeting",
+    '104': "Request",
+    '105': "Persuasion",
+    '106': "Thanks",
+    '107': "Taking Leave",
+    '108': "Admiration",
+    '109': "Finalizing Negotiation/Deal",
+    '110': "Refusing a Request",
+    "none": "None",
+}
 
-
-JSONLSourceFolderId = ""
+JSONLSourceFolderId = "6627ef547193244a6e33353d"
 VideoSourceFolderId = "6602d4a4cb9585b0c24b794f"
 CloneDestinationFolderId = ""
 
 apiURL = "annotation.umd.edu"
 
+processingDirectory = './jsonProcessing'
+tracksDirectory = './tracks'
 def login():
     gc = girder_client.GirderClient(apiURL, port=443, apiRoot='girder/api/v1' )
-    with gc.session() as session:
-        session.verify = False
-        gc.authenticate(interactive=True)
-        return gc
+    gc.authenticate(interactive=True)
+    return gc
 
 
 def getFolderList(gc: girder_client.GirderClient, folderId, parentType = "folder"):
     folders = list(gc.listFolder(folderId, parentFolderType=parentType))
-    print(folders)
     return folders
 
+def getItemList(gc: girder_client.GirderClient, folderId):
+    items = list(gc.listItem(folderId))
+    return items
+
 def get_processVideos(gc, folderId):
-    videoList = getFolderList(VideoSourceFolderId)
+    videoList = getFolderList(gc, VideoSourceFolderId)
     video_dict = {}
     for item in videoList:
-        if "THIRD-PERSON.mp4" in item.name and 'annotate' in item.meta.keys():
-            updated_name = item.name.replace("Video ", "").replace("THIRD-PERSON.mp4", "")
-            video_dict[updated_name] = item.id
+        if "THIRD-PERSON.mp4" in item["name"] and 'annotate' in item["meta"].keys():
+            updated_name = item["name"].replace("Video ", "").replace("_THIRD-PERSON.mp4", "")
+            video_dict[updated_name] = item["_id"]
 
-    print(video_dict)
     return video_dict
 
+def get_processJSONItems(gc: girder_client.GirderClient, folderId):
+    items = list(getItemList(gc, folderId))
+    item_dict = {}
+    for item in items:
+        update_name = item["name"].replace('_converted.json', '').replace('log_', '')
+        item_dict[update_name] = item["_id"]
+    return item_dict
+
+def get_matching_items(video_dict, item_dict):
+    matching = {}
+    for key in item_dict.keys():
+        if video_dict.get(key, False):
+            matching[key] = {"videoId": video_dict[key], "jsonId": item_dict[key]}
+
+    return matching
+
+def download_and_process_json(gc: girder_client.GirderClient, itemId, name):
+    if not os.path.exists(processingDirectory):
+        os.mkdir(processingDirectory)
+    gc.downloadItem(itemId, os.path.join(processingDirectory, name), name=name)
+    # next we need to process the downloaded file and convert it into a track json
+    turns = process_outputjson(os.path.join(processingDirectory, name))
+    trackJSON = convert_output_to_tracks(turns)
+    if not os.path.exists(tracksDirectory):
+        os.mkdir(tracksDirectory)
+    with open(os.path.join(tracksDirectory, name), 'w') as outfile:
+        json.dump(trackJSON, outfile, ensure_ascii=False, indent=True)
+        outfile.write('\n')
 
 
 @click.command(name="removeDups", help="Load in ")
 def run_script():
     gc = login()
-    VideoList = getFolderList(gc, VideoSourceFolderId)
+    video_map = get_processVideos(gc, VideoSourceFolderId)
+    item_map = get_processJSONItems(gc, JSONLSourceFolderId)
+    matching = get_matching_items(video_map, item_map)
+    count = 0
+    limit = 5
+    for key in matching.keys():
+        item = matching[key]
+        download_and_process_json(gc, item["jsonId"], f"{key}.json")
+        count += 1
+        if count > limit:
+            break
+
+
+    
 
 
 
 
+
+def create_or_get_turn(turns, start_time, end_time, time_seconds):
+    
+    for item in turns:
+        if item['startTime'] == start_time and item['endTime'] == end_time:
+            item['startglobal'] = min(time_seconds, item['startglobal'])
+            item['endglobal'] = max(time_seconds, item['endglobal'])
+            return item
+    turn = {
+        'startTime': start_time,
+        'endTime': end_time,
+        'startglobal':time_seconds,
+        'endglobal': time_seconds,
+    }
+    turns.append(turn)
+    return turn
+
+
+def process_outputjson(output):
+    turns = []
+    print('processing output file')
+    translations = []
+    ptt_turns = []
+    for item in output:
+        if item.get('queue', False) == 'AUDIO_SELF' and item.get('message', {}).get('status', False) in ['ptt-pressed', 'ptt-released']:
+            ptt_turns.append({
+                "status": item.get('message', {}).get('status', False),
+                "seconds": item.get('time_seconds')
+            })
+        # we have a turn with ASR information
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TURN' and item.get('message', {}).get('type', False) == 'asr_result':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['ASRText'] = item['message']['asr_text']
+            turn['speaker'] = item['message']['speaker']
+        # translation information
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TURN' and item.get('message', {}).get('type', False) == 'translation':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['translation'] = {
+                'source_language': item['message']['source_language'],
+                'target_language': item['message']['target_language'],
+                'speaker': item['message']['speaker'],
+                'text': item['message']['translation'],
+            }
+        # translation of possible Rephrasing
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TEXT' and item.get('message', {}).get('type', False) == 'translation':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            if turn.get('rephrase_translation', None) is None:
+                turn['rephrase_translation'] = []
+            turn['rephrase_translation'].append({
+                'source_language': item['message']['source_language'],
+                'target_language': item['message']['target_language'],
+                'speaker': item['message']['speaker'],
+                'text': item['message']['translation'],
+                'sourceText': item['message']['text'],
+            })
+        # storing emotions for future use
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('asr_type', False) == 'TURN' and item.get('message', {}).get('type', False) == 'sri_emotions':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['emotions'] = item['message']['emotions']
+        # intent and rudeness
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'intent_and_rudeness':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['intent_and_rudeness'] = {
+                "class1": item['message']['class1'],
+                "class_probability1": item['message']['class_probability1'],
+                "class2": item['message']['class2'],
+                "class_probability2": item['message']['class_probability2'],
+                "rudeness_detected": item['message']['rudeness_detected'],
+                "rudeness_detected_score": item['message']['rudeness_detected_score'],
+            }
+        # paraphrasing results
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'paraphrase_result':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            paraphrase = {}
+            paraphrase['speaker'] = item['message']['speaker']
+            paraphrase['text'] = item['message']['text']
+            paraphrase['critical'] = item['message'].get('paraphrase_critical', False)
+            paraphrase['polite'] = item['message'].get('paraphrase_polite', False)
+            turn['paraphrase'] = paraphrase
+        # norm occurence, can be multiple ones
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'norm_occurrence':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            print(f"NORMS EXISTENCE: {turn.get('norms', None)}")
+            if turn.get('norms', None) is None:
+                turn['norms'] = []
+            turn['norms'].append({
+                'norm': item['message']['norm'],
+                'status': item['message']['status'],
+            })
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'valence':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['valence'] = item['message']['level']
+        if item.get('queue', False) == 'RESULT' and item.get('message', {}).get('type', False) == 'arousal':
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            turn['arousal'] = item['message']['level']
+        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and (item.get('message', {}).get('prefix', False) == 'alert' or item.get('message', {}).get('prefix', False) == 'late') :
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            if turn.get('actions', None) is None:
+                turn['actions'] = []
+            message = item['message']['display'].replace('<i>', '').replace('</i>', '')
+            if not any(d.get('display', False) == message for d in turn['actions']):
+                turn['actions'].append({
+                    'display': message,
+                    'delayed': item.get('message', {}).get('prefix', False) == 'late'
+                })
+        if item.get('queue', False) == 'ACTION' and item.get('message', {}).get('type', False) == 'hololens' and (item.get('message', {}).get('remediation', False) == 'Auto' or 'Added:' in item.get('message', {}).get('display', '')):
+            turn = create_or_get_turn(turns, item['message']['start_seconds'], item['message']['end_seconds'], item['time_seconds'])
+            if turn.get('rephrase', None) is None:
+                turn['rephrase'] = []
+            if not any(d.get('display', False) == item['message']['display'] for d in turn['rephrase']):
+                turn['rephrase'].append({
+                    'display': item['message']['display'],
+                })
+
+    output = []
+    for item in turns:
+        if item.get('ASRText', None) is not None:
+            output.append(item)
+    # with open('ptt-status.json', 'w') as outfile:
+    #     json.dump(ptt_turns, outfile, ensure_ascii=False, indent=True)
+    #     outfile.write('\n')
+
+    return output
+
+def convert_output_to_tracks(output, width=1920, height=1080, framerate=30, offset=5):
+    tracks = {}
+    count = 0
+    offset_frames = framerate * offset
+    beginning_offset = 0
+    for index, item in enumerate(output):
+        start_frame = offset_frames + (framerate * item['startTime']) - beginning_offset
+        if index == 0:
+            beginning_offset = offset_frames
+        print(f'{index+1} < {len(output)}')
+        if (index + 1) < len(output):
+
+            current_endtime = offset_frames + (framerate * item['endTime'])
+            next_start_time = offset_frames + (framerate * output[index + 1]['startTime']) + beginning_offset
+            current_start_global = item['startglobal']
+            next_end_global = output[index + 1]['endglobal']
+            time_length = next_end_global - current_start_global
+            # split the difference
+            print(f' {current_endtime} -- {next_start_time}' )
+            end_frame = start_frame + (framerate * time_length)
+        else:
+            end_frame = offset_frames + (framerate * item['endTime'])
+        track = {
+            "begin": int(start_frame),
+            "end": int(end_frame),
+            "id": count,
+            "confidencePairs": [
+                [
+                    "turn",
+                    1.0
+                ]
+            ],
+            "attributes": {
+                "ASRText": item["ASRText"],
+                "speaker": item["speaker"],
+
+            },
+            "features": [
+                {
+                    "frame": int(start_frame),
+                    "bounds": [
+                        0,
+                        0,
+                        1920,
+                        1080
+                    ],
+                    "interpolate": True,
+                    "keyframe": True,
+                    "attributes": {}
+                },
+                                {
+                    "frame": int(end_frame),
+                    "bounds": [
+                        0,
+                        0,
+                        1920,
+                        1080
+                    ],
+                    "interpolate": True,
+                    "keyframe": True,
+                    "attributes": {}
+                }
+            ]
+
+        }
+        translation = None
+        sourceLanguage = None
+        targetLanguage = None
+
+        if item.get('translation', False):
+            translation = item['translation']['text']
+            sourceLanguage = item['translation']['source_language']
+            targetLanguage = item['translation']['target_language']
+            track['attributes']['translation'] = translation
+            track['attributes']['sourceLanguage'] = sourceLanguage
+            track['attributes']['targetLanguage'] = targetLanguage
+        if item.get('rephrase_translation', False):
+            track['attributes']['rephrase_translation'] = []
+            for rehprase_translation in item['rephrase_translation']:
+                translation = rehprase_translation['text']
+                sourceText = rehprase_translation['sourceText']
+                if not any(d.get('translation') == translation for d in track['attributes']['rephrase_translation']):
+                    track['attributes']['rephrase_translation'].append({
+                        "translation": translation,
+                        "sourceText": sourceText,
+                    })
+
+        emotions = None
+        if item.get('emotions', False):
+            emotions = item['emotions']
+            track['attributes']['emotions'] = emotions
+        if item.get('valence', False):
+            track['attributes']['valence'] = item['valence']
+            track['attributes']['arousal'] = item['arousal']
+        if item.get('norms', False):
+            track['attributes']['norms'] = item['norms']
+        if item.get('actions', False):
+            track['attributes']['alerts'] = item['actions']
+        if item.get('rephrase', False):
+            track['attributes']['rephrase'] = item['rephrase']
+        tracks[count] = track
+        count += 1
+
+    trackJSON = {"tracks": tracks, "groups": {}, "version": 2}
+
+    return trackJSON
 
 if __name__ == '__main__':
     run_script()
+
+

--- a/scripts/convertFolder.py
+++ b/scripts/convertFolder.py
@@ -13,6 +13,12 @@ normMap = {
     '108': "Admiration",
     '109': "Finalizing Negotiation/Deal",
     '110': "Refusing a Request",
+    '111': "Requesting Information",
+    '112': "Granting a Request",
+    '113': "Disagreement",
+    '114': "Respond to Request for Information",
+    '115': "Acknowledging Thanks",
+    '116': "Interrupting",
     "none": "None",
 }
 

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -11,6 +11,12 @@ normMap = {
     '108': "Admiration",
     '109': "Finalizing Negotiation/Deal",
     '110': "Refusing a Request",
+    '111': "Requesting Information",
+    '112': "Granting a Request",
+    '113': "Disagreement",
+    '114': "Respond to Request for Information",
+    '115': "Acknowledging Thanks",
+    '116': "Interrupting",
     "none": "None",
 }
 


### PR DESCRIPTION
resolves #102
resolves #103 

Redesigned Turn creation to reorder tracks by just deleting all the previous items and re-creating them in order.  Other methods were too complicated and filled with corner cases.

- Turn creation now relies on simply removing and adding all tracks are new items are created.
- This mode will delete any current annotations that are in the system, luckily we record all versions of saved tracks so we should be able to go backwards in time and look at them.
