### PR TITLE
inital UI TA2Config

### DIFF
--- a/client/platform/web-girder/api/UMD.service.ts
+++ b/client/platform/web-girder/api/UMD.service.ts
@@ -17,8 +17,25 @@ async function createFilterFolder(folderId: string) {
   return false;
 }
 
+type TA2NormMap = { named: string; id: number; groups: string[] };
+export interface TA2Config {
+  normMap: TA2NormMap[];
+}
+const configAPI = 'UMD_configuration';
+async function getUMDTA2Config() {
+  const result = await girderRest.get<TA2Config>(`${configAPI}/TA2_config`);
+  return result.data;
+}
+
+async function putUMDTA2Config(config: TA2Config) {
+  const result = await girderRest.put(`${configAPI}/TA2_config`, config);
+  return result;
+}
+
 export {
   ingestVideo,
   updateContainers,
   createFilterFolder,
+  getUMDTA2Config,
+  putUMDTA2Config,
 };

--- a/client/platform/web-girder/views/Admin/AdminTA2Config.vue
+++ b/client/platform/web-girder/views/Admin/AdminTA2Config.vue
@@ -1,0 +1,130 @@
+<script lang="ts">
+import { defineComponent, ref, onMounted } from '@vue/composition-api';
+import { getUMDTA2Config, putUMDTA2Config, TA2Config } from 'platform/web-girder/api/UMD.service';
+
+export default defineComponent({
+  name: 'AdminTA2Config',
+  setup() {
+    const normMap = ref<TA2Config['normMap']>([]);
+    const errorMessage = ref<string | null>(null);
+
+    const fetchConfig = async () => {
+      try {
+        const data = await getUMDTA2Config();
+        normMap.value = data.normMap;
+      } catch (error) {
+        console.error(error);
+        errorMessage.value = 'Failed to load configuration.';
+      }
+    };
+
+    const handleFileUpload = async (file?: File) => {
+      if (!file) {
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = async (event) => {
+        try {
+          const config: TA2Config = JSON.parse(event.target?.result as string);
+          await putUMDTA2Config(config);
+          await fetchConfig();
+        } catch (error) {
+          console.error(error);
+          errorMessage.value = 'Invalid JSON file or upload failed.';
+        }
+      };
+      reader.readAsText(file);
+    };
+
+    const downloadConfig = () => {
+      const json = JSON.stringify({ normMap: normMap.value }, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'TA2ConfigNormMap.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    };
+
+    onMounted(() => {
+      fetchConfig();
+    });
+
+    return {
+      normMap,
+      errorMessage,
+      handleFileUpload,
+      downloadConfig,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-container>
+    <v-card class="mt-5">
+      <v-card-title>TA2 Configuration</v-card-title>
+      <v-card-subtitle>
+        Manage and view the TA2 normalization map configuration.
+      </v-card-subtitle>
+      <v-card-text>
+        <v-alert
+          v-if="errorMessage"
+          type="error"
+          dismissible
+          @click:close="errorMessage = null"
+        >
+          {{ errorMessage }}
+        </v-alert>
+
+        <v-data-table
+          :headers="[
+            { text: 'Name', value: 'named' },
+            { text: 'ID', value: 'id' },
+            { text: 'Groups', value: 'groups' }
+          ]"
+          :items="normMap"
+          item-value="id"
+          :items-per-page="-1"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template #item.groups="{ item }">
+            <span
+              v-for="group in item.groups"
+              :key="group"
+              class="mr-2"
+            >
+              {{ group }}
+            </span>
+          </template>
+        </v-data-table>
+
+        <v-file-input
+          label="Upload JSON Configuration"
+          accept="application/json"
+          class="mt-4"
+          @change="handleFileUpload"
+        />
+
+        <v-btn
+          color="primary"
+          class="mt-4"
+          @click="downloadConfig"
+        >
+          Download Current Config
+        </v-btn>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<style scoped>
+.mt-5 {
+  margin-top: 2rem;
+}
+.mt-4 {
+  margin-top: 1.5rem;
+}
+</style>

--- a/client/platform/web-girder/views/Admin/AdminTA2Config.vue
+++ b/client/platform/web-girder/views/Admin/AdminTA2Config.vue
@@ -7,7 +7,7 @@ export default defineComponent({
   setup() {
     const normMap = ref<TA2Config['normMap']>([]);
     const errorMessage = ref<string | null>(null);
-
+    const infoDialog = ref(false);
     const fetchConfig = async () => {
       try {
         const data = await getUMDTA2Config();
@@ -54,6 +54,7 @@ export default defineComponent({
     return {
       normMap,
       errorMessage,
+      infoDialog,
       handleFileUpload,
       downloadConfig,
     };
@@ -66,7 +67,12 @@ export default defineComponent({
     <v-card class="mt-5">
       <v-card-title>TA2 Configuration</v-card-title>
       <v-card-subtitle>
-        Manage and view the TA2 normalization map configuration.
+        Manage and view the TA2 normalization map configuration. <v-icon
+          class="mx-2"
+          @click="infoDialog = true"
+        >
+          mdi-information
+        </v-icon>
       </v-card-subtitle>
       <v-card-text>
         <v-alert
@@ -117,6 +123,34 @@ export default defineComponent({
         </v-btn>
       </v-card-text>
     </v-card>
+    <v-dialog
+      v-model="infoDialog"
+      width="500"
+    >
+      <v-card>
+        <v-card-title>TA2 Configuration Information</v-card-title>
+        <v-card-text>
+          <p>
+            The TA2 Configuration allows uploading a Configiuration JSON file.
+          </p>
+          <p> The file should have a root JSON object with a key of 'normMap' which is an array of items</p>
+          <p> These items should include a format like the following 'name: NormName, id: 101, groups: ['LC1', 'LC2']'</p>
+          <p> The normMap name will only appear in the interace for TA2 Annotations when the filename contains one of the text strings found in groups.  I.E. if the filename contains LC1 it will enable the norm for TA2 Norm annotations</p>
+        </v-card-text>
+        <v-card-actions>
+          <v-row dense>
+            <v-spacer />
+            <v-btn
+              color="primary"
+              @click="infoDialog = false"
+            >
+              Close
+            </v-btn>
+            <v-spacer />
+          </v-row>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 

--- a/client/platform/web-girder/views/AdminPage.vue
+++ b/client/platform/web-girder/views/AdminPage.vue
@@ -6,6 +6,7 @@ import UserRecents from './Admin/UserRecents.vue';
 import AdminJobs from './Admin/AdminJobs.vue';
 import AdminBranding from './Admin/AdminBranding.vue';
 import AdminUpdate from './Admin/AdminUpdate.vue';
+import AdminTA2ConfigVue from './Admin/AdminTA2Config.vue';
 
 export default {
   name: 'AdminPage',
@@ -16,6 +17,7 @@ export default {
     AdminJobs,
     AdminBranding,
     AdminUpdate,
+    AdminTA2ConfigVue,
   },
   props: {
   },
@@ -38,6 +40,7 @@ export default {
           <v-tab> Jobs </v-tab>
           <v-tab> Addons </v-tab>
           <v-tab> Branding </v-tab>
+          <v-tab> TA2 Config </v-tab>
           <v-tab> Update </v-tab>
         </v-tabs>
       </v-card-title>
@@ -56,6 +59,9 @@ export default {
         </v-tab-item>
         <v-tab-item>
           <AdminBranding />
+        </v-tab-item>
+        <v-tab-item>
+          <AdminTA2ConfigVue />
         </v-tab-item>
         <v-tab-item>
           <AdminUpdate />

--- a/client/src/components/UMDTA2Annotation.vue
+++ b/client/src/components/UMDTA2Annotation.vue
@@ -14,6 +14,7 @@ import {
 } from 'vue-media-annotator/provides';
 import { usePrompt } from 'dive-common/vue-utilities/prompt-service';
 import { UMDAnnotationMode } from 'platform/web-girder/store/types';
+import { getUMDTA2Config } from 'platform/web-girder/api/UMD.service';
 import UMDTA2Translation, { TA2Translation } from './UMDTA2Translation.vue';
 import UMDTA2AnnotationWizard, { TA2Annotation } from './UMDTA2AnnotationWizard.vue';
 
@@ -61,23 +62,13 @@ export default defineComponent({
     const userLogin = ref('');
     const loadedAttributes = ref(false);
     const annotation: Ref<TA2Annotation | null> = ref({});
-
+    const normFileNames: Ref<string[]> = ref([]);
     const LCName = computed(() => {
       if (props.name) {
-        if (props.name.includes('LC1')) {
-          return 'LC1';
-        }
-        if (props.name.includes('LC2')) {
-          return 'LC2';
-        }
-        if (props.name.includes('LC2')) {
-          return 'LC1';
-        }
-        if (props.name.includes('LC3')) {
-          return 'LC3';
-        }
-        if (props.name.includes('LC4')) {
-          return 'LC4';
+        for (let i = 0; i < normFileNames.value.length; i += 1) {
+          if (props.name.includes(normFileNames.value[i])) {
+            return normFileNames.value[i];
+          }
         }
       }
       return 'LC1';
@@ -230,6 +221,14 @@ export default defineComponent({
         getMaxSegmentAnnotated();
       }
       loadedAttributes.value = checkAttributes(selectedTrackIdRef.value, true);
+      const config = await getUMDTA2Config();
+      if (config.normMap) {
+        const fileNames = new Set<string>();
+        config.normMap.forEach((item) => {
+          item.groups.forEach((group) => fileNames.add(group));
+        });
+        normFileNames.value = Array.from(fileNames);
+      }
     };
     onMounted(() => initialize());
     watch(selectedTrackIdRef, () => {

--- a/scripts/IngestingTA2Annotations/JSONLConverter.py
+++ b/scripts/IngestingTA2Annotations/JSONLConverter.py
@@ -1,8 +1,11 @@
 import argparse
 import json
 import os
+import girder_client
+apiURL = "localhost" # "annotation.umd.edu" # localhost
+apiPort = 8010
 
-normMap = {
+baseNormMap = {
     '101': "Apology",
     '102': "Criticism",
     '103': "Greeting",
@@ -24,6 +27,23 @@ normMap = {
     '119': 'Giving Advice',
     "none": "None",
 }
+normMap = {}
+
+def login():
+    gc = girder_client.GirderClient(apiURL, port=apiPort, apiRoot='girder/api/v1' )
+    gc.authenticate(interactive=True)
+    return gc
+
+
+def get_server_normMap(gc: girder_client.GirderClient):
+    global normMap
+    data = gc.get('/UMD_configuration/TA2_config')
+    norms = data['normMap']
+    normMap = baseNormMap
+    for item in norms:
+        print(item)
+        normMap[str(item['id'])] = item['named']
+
 
 def try_open_file(input_file):
     encodings = ['utf-8', 'latin-1', 'cp1252']
@@ -94,6 +114,8 @@ def process_folder(folder_path):
                 print("Base64 data removed and saved to:", output_file)
 
 def main():
+    gc = login()
+    get_server_normMap(gc)
     parser = argparse.ArgumentParser(description='Process JSONL files in a folder and remove base64 data from them.')
     parser.add_argument('folder_path', help='Folder path containing JSONL files')
     args = parser.parse_args()

--- a/scripts/IngestingTA2Annotations/cloneAndConvert.py
+++ b/scripts/IngestingTA2Annotations/cloneAndConvert.py
@@ -21,7 +21,7 @@ apiURL = "annotation.umd.edu"
 processingDirectory = './jsonProcessing'
 tracksDirectory = './tracks'
 
-normMap = {
+baseNormMap = {
     '101': "Apology",
     '102': "Criticism",
     '103': "Greeting",
@@ -43,12 +43,22 @@ normMap = {
     '119': 'Giving Advice',
     "none": "None",
 }
+normMap = {}
 
 
 def login():
     gc = girder_client.GirderClient(apiURL, port=443, apiRoot='girder/api/v1' )
     gc.authenticate(interactive=True)
     return gc
+
+def get_server_normMap(gc: girder_client.GirderClient):
+    global normMap
+    data = gc.get('/UMD_configuration/TA2_config')
+    norms = data['normMap']
+    normMap = baseNormMap
+    for item in norms:
+        print(item)
+        normMap[str(item['id'])] = item['named']
 
 
 def getFolderList(gc: girder_client.GirderClient, folderId, parentType = "folder"):
@@ -655,6 +665,7 @@ def replace_exising_alerts(gc: girder_client.GirderClient, existing_id, newTrack
 @click.command(name="cloneAndConvert", help="Load in ")
 def run_script():
     gc = login()
+    get_server_normMap()
     video_map = get_processVideos(gc)
     clng_videos = extract_CLNG_videos(video_map)
     existing_videos = get_existingVideos(gc, CloneDestinationFolderId)

--- a/scripts/TabToJSON.py
+++ b/scripts/TabToJSON.py
@@ -4,8 +4,11 @@ import json
 import math
 import csv
 from collections import OrderedDict
+import girder_client
+apiURL = "annotation.umd.edu" # localhost
+apiPort = 443 # 8000
 
-normMap = {
+baseNormMap = {
     '101': "Apology",
     '102': "Criticism",
     '103': "Greeting",
@@ -25,7 +28,21 @@ normValMap = {
     'EMPTY_NA': 'EMPTY_NA',
     'adhere_violate': 'adhered_violated'
 }
+normMap = {}
 
+def login():
+    gc = girder_client.GirderClient(apiURL, port=apiPort, apiRoot='girder/api/v1' )
+    gc.authenticate(interactive=True)
+    return gc
+
+
+def get_server_normMap(gc: girder_client.GirderClient):
+    global normMap
+    data = gc.get('/UMD_configuration/TA2_config')
+    norms = data['normMap']
+    normMap = baseNormMap
+    for item in norms:
+        normMap[str(item['id'])] = item['named']
 
 
 def loadUserMap(csvfile):
@@ -198,6 +215,8 @@ def generate_tracks(videoinfo):
 )
 @click.argument("trackfile")
 def load_data(trackfile):
+    gc = login()
+    get_server_normMap()
    #tracks = loadExistingTracks(trackfile)
     videoinfo = {
         'width': 1920,

--- a/server/UMD_server/UMD_configuation/views.py
+++ b/server/UMD_server/UMD_configuation/views.py
@@ -35,13 +35,13 @@ BASENORMMAP = [
 
 
 class TA2NormMapping(BaseModel):
-    name: str
+    named: str
     id: int
     groups: List[str]
 
 
 class TA2Config(BaseModel):
-    normMapping: List[TA2NormMapping]
+    normMap: List[TA2NormMapping]
 
     class Config:
         extra = 'forbid'
@@ -74,7 +74,7 @@ class ConfigurationResource(Resource):
     @access.public
     @autoDescribeRoute(Description("Get TA2 Config"))
     def get_ta2_config(self):
-        return Setting().get(TA2_CONFIG) or BASENORMMAP
+        return Setting().get(TA2_CONFIG) or {'normMap': BASENORMMAP}
 
     @access.admin
     @autoDescribeRoute(

--- a/server/UMD_server/UMD_configuration/views.py
+++ b/server/UMD_server/UMD_configuration/views.py
@@ -8,31 +8,7 @@ from pydantic.main import BaseModel
 import pydantic
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-TA2_CONFIG = 'TA2_config'
-
-BASENORMMAP = [
-    {"named": 'No Norm', "id": 100, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
-    {"named": 'Apology', "id": 101, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
-    {"named": 'Criticism', "id": 102, "groups": ['LC1', 'LC2']},
-    {"named": 'Greeting', "id": 103, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
-    {"named": 'Request', "id": 104, "groups": ['LC1']},
-    {"named": 'Persuasion', "id": 105, "groups": ['LC1']},
-    {"named": 'Thanks', "id": 106, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
-    {"named": 'Taking Leave', "id": 107, "groups": ['LC1']},
-    {"named": 'Admiration', "id": 108, "groups": ['LC1', 'LC2', 'LC3']},
-    {"named": 'Finalizing Negotiation/Deal', "id": 109, "groups": ['LC1', 'LC2']},
-    {"named": 'Refusing a Request', "id": 110, "groups": ['LC1', 'LC2']},
-    {"named": 'Requesting Information', "id": 111, "groups": ['LC2', 'LC3']},
-    {"named": 'Granting a Request', "id": 112, "groups": ['LC2', 'LC3', 'LC4']},
-    {"named": 'Disagreement', "id": 113, "groups": ['LC2', 'LC3']},
-    {"named": 'Respond to Request for Information', "id": 114, "groups": ['LC3', 'LC4']},
-    {"named": 'Acknowledging Thanks', "id": 115, "groups": ['LC3', 'LC4']},
-    {"named": 'Interrupting', "id": 116, "groups": ['LC3', 'LC4']},
-    {"named": 'Complaining', "id": 117, "groups": ['LC4']},
-    {"named": 'Topic Closing', "id": 118, "groups": ['LC4']},
-    {"named": 'Giving Advice', "id": 119, "groups": ['LC4']},
-]
-
+from UMD_utils.constants import TA2_CONFIG, BASENORMMAP
 
 class TA2NormMapping(BaseModel):
     named: str

--- a/server/UMD_server/__init__.py
+++ b/server/UMD_server/__init__.py
@@ -3,7 +3,7 @@ from girder import plugin, events
 from .UMD_dataset.views import UMD_Dataset
 from .client_webroot import ClientWebroot
 from .UMD_dataset.event import process_s3_import
-from .UMD_configuation.views import ConfigurationResource
+from .UMD_configuration.views import ConfigurationResource
 class UMDPlugin(plugin.GirderPlugin):
     def load(self, info):
         info["apiRoot"].UMD_dataset = UMD_Dataset()

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -14,7 +14,6 @@ from girder.utility import ziputil
 from girder.models.setting import Setting
 from UMD_utils.constants import TA2_CONFIG, BASENORMMAP
 
-base_norm_map = Setting().get(TA2_CONFIG).get('normMap', None) or BASENORMMAP
 
 
 normMap = {
@@ -42,8 +41,6 @@ normMap = {
     "No Norm": 'none',
 }
 
-for item in base_norm_map:
-    normMap[item['named']] = item['id']
 
 normMap['No Norm'] = 'none'
 
@@ -332,6 +329,10 @@ def handle_norms_export(session_id, user_norms, system_norms):
 
 
 def export_ta2_annotation(folders, userMap, user):
+    base_norm_map = Setting().get(TA2_CONFIG).get('normMap', None) or BASENORMMAP
+    for item in base_norm_map:
+        normMap[item['named']] = item['id']
+
     csvFile = io.StringIO()
     writer = csv.writer(csvFile, delimiter='\t')
     writer.writerow(

--- a/server/UMD_utils/UMD_export.py
+++ b/server/UMD_utils/UMD_export.py
@@ -11,6 +11,11 @@ from girder.constants import AccessType
 from girder.models.folder import Folder
 from girder.models.user import User
 from girder.utility import ziputil
+from girder.models.setting import Setting
+from UMD_utils.constants import TA2_CONFIG, BASENORMMAP
+
+base_norm_map = Setting().get(TA2_CONFIG).get('normMap', None) or BASENORMMAP
+
 
 normMap = {
     "Apology": 101,
@@ -37,6 +42,10 @@ normMap = {
     "No Norm": 'none',
 }
 
+for item in base_norm_map:
+    normMap[item['named']] = item['id']
+
+normMap['No Norm'] = 'none'
 
 normValuesViolate = ['violate', 'violated']
 normValuesAdhere = ['adhere', 'adhered']

--- a/server/UMD_utils/constants.py
+++ b/server/UMD_utils/constants.py
@@ -2,3 +2,29 @@ FPSMarker = "fps"
 OriginalFPSMarker = "originalFps"
 OriginalFPSStringMarker = "originalFpsString"
 AnnotationFilterMarker = 'annotationFilter'
+
+
+TA2_CONFIG = 'TA2_config'
+
+BASENORMMAP = [
+    {"named": 'No Norm', "id": 100, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
+    {"named": 'Apology', "id": 101, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
+    {"named": 'Criticism', "id": 102, "groups": ['LC1', 'LC2']},
+    {"named": 'Greeting', "id": 103, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
+    {"named": 'Request', "id": 104, "groups": ['LC1']},
+    {"named": 'Persuasion', "id": 105, "groups": ['LC1']},
+    {"named": 'Thanks', "id": 106, "groups": ['LC1', 'LC2', 'LC3', 'LC4']},
+    {"named": 'Taking Leave', "id": 107, "groups": ['LC1']},
+    {"named": 'Admiration', "id": 108, "groups": ['LC1', 'LC2', 'LC3']},
+    {"named": 'Finalizing Negotiation/Deal', "id": 109, "groups": ['LC1', 'LC2']},
+    {"named": 'Refusing a Request', "id": 110, "groups": ['LC1', 'LC2']},
+    {"named": 'Requesting Information', "id": 111, "groups": ['LC2', 'LC3']},
+    {"named": 'Granting a Request', "id": 112, "groups": ['LC2', 'LC3', 'LC4']},
+    {"named": 'Disagreement', "id": 113, "groups": ['LC2', 'LC3']},
+    {"named": 'Respond to Request for Information', "id": 114, "groups": ['LC3', 'LC4']},
+    {"named": 'Acknowledging Thanks', "id": 115, "groups": ['LC3', 'LC4']},
+    {"named": 'Interrupting', "id": 116, "groups": ['LC3', 'LC4']},
+    {"named": 'Complaining', "id": 117, "groups": ['LC4']},
+    {"named": 'Topic Closing', "id": 118, "groups": ['LC4']},
+    {"named": 'Giving Advice', "id": 119, "groups": ['LC4']},
+]


### PR DESCRIPTION
resolves #129 

- Adds in Girder Configuration for TA2Config that contains a main object normMap.  normMap contains a list of norms that can be used `{named: string; id: number; groups: string[] }`.  Were the groups is a list of Strings that are found within the Name of a file to determine what Norms are applied to the files.
- The TA2 Annotation interface now reads from the `/UMD_configuration/TA2_config` endpoint to get the normMap and decide on what norms to display.
- There is an Admin page that allows an admin to view the norms and to also upload a new JSON file with more norms that can be added to the system.

![image](https://github.com/user-attachments/assets/7477af6e-364e-4a05-89e9-e63867499a5f)


TODO:
- [x] Back-End exporting code needs to be updated to use the new settings NormMapping instead of a static list of the norms.  server/UMD_utils/UMD_export.py.
- [x] Additional Scripts need to be updated to request the config from the server before performing the conversion process.  There should hopefully be a simple copy and paste code snippet I can create to handle this.
    - [x] scripts/base64_stripper.py
    - [x] scripts/CheckScript.py
    - [x] scripts/converter.py
    - [x] scripts/TabToJSON.py
    - [x] scripts/cloneAndConvert.py -- IMPORTANT
    - [x] scripts/JSONLConverter.py
- [x] Testing of the new scripts and the Configuration endpoint